### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Also see the [Dockerfile](Dockerfile) for more information.
 
  
  ```bash
- docker run -d -p 80:80 -t freeciv-web
+ docker run -d -p 80:80 --expose=80 -t freeciv-web /bin/sh -c "/docker/scripts/docker-run.sh && sleep infinity"
  ```
 
 System Requirements for manual install


### PR DESCRIPTION
as far as i can tell, the version listed in the README doesn't actually start the server, it sits in 'docker ps' as /bin/bash, which means you should be in -i (interactive) mode.

The version i propose actually starts freeciv-web, and exposes port 80, and keeps the container open forever.

you can view proof by doing this command and then watch docker logs [container]