### PR TITLE
WebGL: Use a better resolution and algorithm for the relief

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/webgl/heightmap.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/heightmap.js
@@ -89,8 +89,7 @@ function create_heightmap()
         heightmap[x][y] = heightmap_tiles[gx][gy];
       } else {
         /* Interpolate between neighbouring tiles, with each tile having weight:
-         *  weight = 1 / (distance to the tile + 1).
-         * The +1 is there to avoid divergence.
+         * 1 / (distance to the tile)^2.
          */
         var neighbours = [
           { "x": Math.floor(gx), "y": Math.floor(gy) },
@@ -110,9 +109,8 @@ function create_heightmap()
           var dx = gx - coords.x;
           var dy = gy - coords.y;
           var distance = Math.sqrt(dx*dx + dy*dy);
-          var D = 0.;
-          sum += heightmap_tiles[coords.x][coords.y] / (distance + D) / (distance + D);
-          norm += 1. / (distance + D) / (distance + D);
+          sum += heightmap_tiles[coords.x][coords.y] / distance / distance;
+          norm += 1. / distance / distance;
         }
         heightmap[x][y] = sum / norm;
       }

--- a/freeciv-web/src/main/webapp/javascript/webgl/mapview.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/mapview.js
@@ -208,12 +208,10 @@ function render_testmap() {
 
   for ( var i = 0, l = landGeometry.vertices.length; i < l; i ++ ) {
     var x = i % xquality, y = Math.floor( i / xquality );
-    var gx = Math.floor(map.xsize*x/xquality);
-    var gy = Math.floor(map.ysize*y/yquality);
     if (heightmap[x] != null && heightmap[x][y] != null) {
       landGeometry.vertices[ i ].y = heightmap[x][y] * 100;
     } else {
-      console.log("x: " + x + ", y: " + y + " not found in heightmap.");
+      //console.log("x: " + x + ", y: " + y + " not found in heightmap.");
     }
 
   }

--- a/freeciv-web/src/main/webapp/javascript/webgl/mapview.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/mapview.js
@@ -195,23 +195,25 @@ function render_testmap() {
     fragmentShader: fragShader
   });
 
-  var quality = map['xsize'] * 2, step = 1024 / quality;
+  var xquality = map.xsize * 4 + 1;
+  var yquality = map.ysize * 4 + 1;
+  var step = 1024 / quality;
 
   /* LandGeometry is a plane representing the landscape of the map. */
-  var landGeometry = new THREE.PlaneGeometry( 3000, 2000, quality - 1, quality - 1 );
+  var landGeometry = new THREE.PlaneGeometry(3000, 2000, xquality - 1, yquality - 1);
   landGeometry.rotateX( - Math.PI / 2 );
   landGeometry.translate(1000, 0, 1000);
 
 
 
   for ( var i = 0, l = landGeometry.vertices.length; i < l; i ++ ) {
-    var x = i % quality, y = Math.floor( i / quality );
-    var gx = Math.floor(map['xsize']*x/quality);
-    var gy = Math.floor(map['ysize']*y/quality);
-    if (heightmap[gx] != null && heightmap[gx][gy] != null) {
-      landGeometry.vertices[ i ].y = heightmap[gx][gy] * 100;
+    var x = i % xquality, y = Math.floor( i / xquality );
+    var gx = Math.floor(map.xsize*x/xquality);
+    var gy = Math.floor(map.ysize*y/yquality);
+    if (heightmap[x] != null && heightmap[x][y] != null) {
+      landGeometry.vertices[ i ].y = heightmap[x][y] * 100;
     } else {
-      //console.log("x: " + gx + ", y: " + gy + " not found in heightmap.");
+      console.log("x: " + x + ", y: " + y + " not found in heightmap.");
     }
 
   }


### PR DESCRIPTION
![spectacle m30211](https://cloud.githubusercontent.com/assets/22327575/20235588/2de28de0-a896-11e6-907e-9dcd5b5f59fc.png)
This overhauls create_heightmap to use 16 vertices/tile.
The base height of a tile is the sum of two components: the distance to the sea and the terrain intrinsic height.
The tile height are then interpolated with a weight chosen to have smooth landscapes where the elevation doesn't vary much and steep slopes where it does.