### PR TITLE
Do not assume that python3.5 is present

### DIFF
--- a/pbem/README.md
+++ b/pbem/README.md
@@ -7,7 +7,7 @@ Requires:
 https://github.com/mysql/mysql-connector-python
 
 Run like this:
-python3.5 pbem.py
+python3 pbem.py
 
 Freeciv-pbem is automatically started by start-freeciv-web.sh script
 Python unit tests are found in test_pbem.py.

--- a/publite2/init-freeciv-web.sh
+++ b/publite2/init-freeciv-web.sh
@@ -17,7 +17,7 @@ ulimit -t 10000 && ulimit -Sv 500000 && \
 export FREECIV_SAVE_PATH=${1};
 rm -f /var/lib/tomcat8/webapps/data/scorelogs/score-${2}.log; 
 
-python3.5 ../freeciv-proxy/freeciv-proxy.py ${3} > ../logs/freeciv-proxy-${3}.log 2>&1 & 
+python3 ../freeciv-proxy/freeciv-proxy.py ${3} > ../logs/freeciv-proxy-${3}.log 2>&1 &
 proxy_pid=$! && 
 ${HOME}/freeciv/bin/freeciv-web --debug=1 --port ${2} -q 20 --Announce none -e  -m \
 -M http://${4} --type ${5} --read pubscript_${5}.serv --log ../logs/freeciv-web-log-${2}.log \

--- a/publite2/run.sh
+++ b/publite2/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-nohup python3.5 -u publite2.py > ../logs/publite2.log 2>&1 || tail -5 ../logs/publite2.log && sleep 5  &
+nohup python3 -u publite2.py > ../logs/publite2.log 2>&1 || tail -5 ../logs/publite2.log && sleep 5  &

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -49,7 +49,7 @@ cd /tmp
 wget ${tornado_url}
 tar xvfz tornado-4.2.1.tar.gz
 cd tornado-4.2.1
-python3.5 setup.py install
+python3 setup.py install
 
 pip3 install wikipedia
 

--- a/scripts/freeciv-img-extract/sync.sh
+++ b/scripts/freeciv-img-extract/sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "running Freeciv-img-extract..."
-python3.5 img-extract.py &&
+python3 img-extract.py &&
 pngcrush pre-freeciv-web-tileset-amplio2-0.png freeciv-web-tileset-amplio2-0.png &&
 pngcrush pre-freeciv-web-tileset-amplio2-1.png freeciv-web-tileset-amplio2-1.png &&
 pngcrush pre-freeciv-web-tileset-amplio2-2.png freeciv-web-tileset-amplio2-2.png &&

--- a/scripts/start-freeciv-web.sh
+++ b/scripts/start-freeciv-web.sh
@@ -31,13 +31,13 @@ echo "Starting publite2" && \
 sh run.sh) && \
 echo "Publite2 started" && \
 echo "Starting Freeciv-PBEM" && \
-cd ${FREECIV_WEB_DIR}/pbem/ && nohup python3.5 -u pbem.py > ../logs/pbem.log 2>&1 || echo "unable to start pbem" & 
+cd ${FREECIV_WEB_DIR}/pbem/ && nohup python3 -u pbem.py > ../logs/pbem.log 2>&1 || echo "unable to start pbem" &
 
 echo "starting meta-stats.py" && \
-cd ${FREECIV_WEB_DIR}/scripts/meta-stats && nohup python3.5 -u meta-stats.py > ../../logs/meta-stats.log 2>&1 || echo "unable to start meta-stats" & 
+cd ${FREECIV_WEB_DIR}/scripts/meta-stats && nohup python3 -u meta-stats.py > ../../logs/meta-stats.log 2>&1 || echo "unable to start meta-stats" &
 
 echo "Starting Freeciv-Earth-mapgen." && \
-cd ${FREECIV_WEB_DIR}/freeciv-earth/ && nohup python3.5 -u freeciv-earth-mapgen.py > ../logs/freeciv-earth.log 2>&1 || echo "unable to start freeciv-earth-mapgen" & 
+cd ${FREECIV_WEB_DIR}/freeciv-earth/ && nohup python3 -u freeciv-earth-mapgen.py > ../logs/freeciv-earth.log 2>&1 || echo "unable to start freeciv-earth-mapgen" &
 
 echo "Will sleep for 8 seconds, then do a status test..." && \
 sleep 8 && \

--- a/scripts/sync-js-hand.sh
+++ b/scripts/sync-js-hand.sh
@@ -13,11 +13,11 @@ cp packets.js ../freeciv-web/src/main/webapp/javascript/ && \
 mkdir -p ${DATADIR}savegames/ && \
 mkdir -p ${DATADIR}savegames/pbem/ && \
 cp ../freeciv/freeciv/data/scenarios/*.sav ${DATADIR}savegames/ && \
-python3.5 helpdata_gen/helpdata_gen.py &&\
+python3 helpdata_gen/helpdata_gen.py &&\
 cp freeciv-helpdata.js ../freeciv-web/src/main/webapp/javascript/ && \
 sh helpdata_gen/ruleset_auto_gen.sh && \
 cp ../LICENSE.txt ../freeciv-web/src/main/webapp/docs/ &&
 mkdir -p ../freeciv-web/src/main/webapp/sounds/  && \
 cp ../freeciv/freeciv/data/stdsounds/*.ogg ../freeciv-web/src/main/webapp/sounds/ && \
-cd soundspec-extract && python3.5 soundspec-extract.py && cp soundset_spec.js ../../freeciv-web/src/main/webapp/javascript/ && \
+cd soundspec-extract && python3 soundspec-extract.py && cp soundset_spec.js ../../freeciv-web/src/main/webapp/javascript/ && \
 echo "done with sync-js-hand!"

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -43,8 +43,8 @@ apt-get -y update
 echo "apt-get install dependencies"
 apt-get -y install ${dependencies}
 
-ln -s /usr/bin/python3.4 /usr/bin/python3.5
-python3.5 -m easy_install Pillow
+ln -s /usr/bin/python3.4 /usr/bin/python3
+python3 -m easy_install Pillow
 
 echo "===== Install Tomcat 8 ======="
 echo "if you get a download error 404 here, then there could be a new Tomcat version released, so update the URL below."
@@ -61,14 +61,14 @@ echo "==== Fetching/Installing Tornado Web Server ===="
 wget ${tornado_url}
 tar xfz v4.4.1.tar.gz
 cd tornado-4.4.1
-python3.5 setup.py install
+python3 setup.py install
 
 ## build and install mysql-connector-python
 cd /tmp
 wget --quiet https://github.com/mysql/mysql-connector-python/archive/2.1.3.zip
 unzip 2.1.3.zip
 cd mysql-connector-python-2.1.3
-python3.5 setup.py install
+python3 setup.py install
 
 ## mysql setup
 echo "==== Setting up MySQL ===="
@@ -139,7 +139,7 @@ xvfb-run casperjs --engine=phantomjs test freeciv-web-tests.js || (>&2 echo "Fre
 
 echo "running pbem unit tests."
 cd ${basedir}/pbem
-python3.5 test_pbem.py
+python3 test_pbem.py
 
 #echo "=============================="
 echo "Freeciv-web built, tested and started correctly: Build successful!"

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -43,7 +43,6 @@ apt-get -y update
 echo "apt-get install dependencies"
 apt-get -y install ${dependencies}
 
-ln -s /usr/bin/python3.4 /usr/bin/python3
 python3 -m easy_install Pillow
 
 echo "===== Install Tomcat 8 ======="


### PR DESCRIPTION
Python 3.6 is out and distributed by Arch (and it _replaces_ version 3.5). Freeciv-web thus cannot be built on an up-to-date Arch system. The proposed changes fix the problem.