### PR TITLE
Cleanup servlet code

### DIFF
--- a/freeciv-web/src/main/java/org/freeciv/servlet/CivclientLauncher.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/CivclientLauncher.java
@@ -1,23 +1,20 @@
-/**********************************************************************
-    Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
-    Copyright (C) 2009-2015  The Freeciv-web project
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-***********************************************************************/
-
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -33,91 +30,115 @@ import javax.naming.*;
 /**
  * This class is responsible for finding an available freeciv-web server for clients
  * based on information in the metaserver database.
+ *
+ * URL: /civclientlauncher
  */
 public class CivclientLauncher extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-		/* Parse input parameters.. */
-        String action = request.getParameter("action");
-        if (action == null) action = "new";
+		// Parse input parameters ...
+		String action = request.getParameter("action");
+		if (action == null) {
+			action = "new";
+		}
 
-        String civServerPort = request.getParameter("civserverport");
+		String civServerPort = request.getParameter("civserverport");
 
-        Connection conn = null;
-        try {
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
+		Connection conn = null;
+		try {
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
+			
+			String gameType;
+			switch (action) {
+			case "new":
+			case "load":
+			case "hotseat":
+			case "earthload":
+				gameType = "singleplayer";
+				break;
+			case "pbem":
+				gameType = "pbem";
+				break;
+			default:
+				response.setHeader("result", "invalid port validation");
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+						"Unable to find a valid Freeciv server to play on. Please try again later.");
+				return;
+			}
+			
 
-            if (!action.equals("multi") && (action.equals("new") || action.equals("load") || action.equals("pbem") 
-                || action.equals("earthload") || action.equals("hotseat"))) {
-               String gametype = "singleplayer";
-               if (action.equals("pbem")) gametype = "pbem"; 
+			// If the user requested a new game, then get host and port for an available
+			// server from the metaserver DB, and use that one.
+			String lookupQuery =
+					  "SELECT port "
+					+ "FROM servers "
+					+ "WHERE state = 'Pregame' "
+					+ "	AND type = ? "
+					+ "	AND humans = '0' "
+					+ "ORDER BY RAND() "
+					+ "LIMIT 1 ";
 
-               /* If user requested a new game, then get host and port for an available
-               * server from the metaserver DB, and use that one. */
+			PreparedStatement lookupStmt = conn.prepareStatement(lookupQuery);
+			lookupStmt.setString(1, gameType);
+			ResultSet lookupRs = lookupStmt.executeQuery();
+			if (lookupRs.next()) {
+				civServerPort = Integer.toString(lookupRs.getInt(1));
+			} else {
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+						"No servers available for creating a new game on.");
+				return;
+			}
 
-                String serverFetchSql = "select port from servers where state = 'Pregame' and type = '" 
-                                         + gametype + "' and humans = '0' order by rand() limit 1";
+			/* Validate port */
+			String validateQuery = "SELECT COUNT(*) FROM servers WHERE port = ?";
+			PreparedStatement validateStmt = conn.prepareStatement(validateQuery);
+			if (civServerPort == null) {
+				response.setHeader("result", "invalid port validation");
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+						"Unable to find a valid Freeciv server to play on. Please try again later.");
+				return;
+			}
 
-                PreparedStatement stmt = conn.prepareStatement(serverFetchSql);
-                ResultSet rs = stmt.executeQuery();
-                if (rs.next()) {
-                    civServerPort = Integer.toString(rs.getInt(1));
-                } else {
-                    response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                            "No servers available for creating a new game on.");
-                    return;
-                }
-            }
+			validateStmt.setInt(1, Integer.parseInt(civServerPort));
+			ResultSet validateRs = validateStmt.executeQuery();
+			validateRs.next();
+			if (validateRs.getInt(1) != 1) {
+				response.setHeader("result", "invalid port validation");
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+						"Invalid input values to civclient.");
+				return;
+			}
 
-		  /* Validate port */
-            PreparedStatement stmt = conn.prepareStatement("SELECT count(*) FROM servers WHERE port = ?");
-            if (civServerPort == null) {
-              response.setHeader("result", "invalid port validation");
-              response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                            "Unable to find a valid Freeciv server to play on. Please try again later.");
-              return;
-            }
+		} catch (Exception err) {
+			response.setHeader("result", err.getMessage());
+			err.printStackTrace();
+			return;
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
 
-            stmt.setInt(1, Integer.parseInt(civServerPort));
-            ResultSet rs = stmt.executeQuery();
-            rs.next();
-            if (rs.getInt(1) != 1) {
-                response.setHeader("result", "invalid port validation");
-                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                        "Invalid input values to civclient.");
-                return;
-            }
+		response.setHeader("port", civServerPort);
+		response.setHeader("result", "success");
+		response.setHeader("action", action);
+		response.getOutputStream().print("success");
 
-        } catch (Exception err) {
-            response.setHeader("result", err.getMessage());
-            err.printStackTrace();
-            return;
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
+	}
 
-        response.setHeader("port", civServerPort);
-        response.setHeader("result", "success");
-        response.setHeader("action", action);
-        response.getOutputStream().print("success");
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-    }
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Freeciv-web civclientlauncher servlet: Please use HTTP Post.");
-
-    }
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/DeactivateUser.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/DeactivateUser.java
@@ -1,23 +1,20 @@
-/**********************************************************************
-    Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
-    Copyright (C) 2009-2015  The Freeciv-web project
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-***********************************************************************/
-
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -32,56 +29,58 @@ import javax.naming.*;
 
 /**
  * Deactivate a user account.
+ *
+ * URL: /deactivate_user
  */
 public class DeactivateUser extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-        String username = request.getParameter("username");
-        String password = request.getParameter("password");
-       
-
-       Connection conn = null;
-        try {
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
-
-            String pwdSQL = "UPDATE auth set activated='0' where username = ? and password = MD5(?)";
-            PreparedStatement preparedStatement = conn.prepareStatement(pwdSQL);
-            preparedStatement.setString(1, username);
-            preparedStatement.setString(2, password);
-            int no_updated = preparedStatement.executeUpdate();
-            if (no_updated == 1) { 
-            	response.getOutputStream().print("OK!");
-            } else {
-            	response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to deactivate user.");
-            }
+		String username = request.getParameter("username");
+		String password = request.getParameter("password");
 
 
-      } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
+		Connection conn = null;
+		try {
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
+
+			String query = "UPDATE auth SET activated = '0' WHERE username = ? AND password = MD5(?)";
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			preparedStatement.setString(1, username);
+			preparedStatement.setString(2, password);
+			int no_updated = preparedStatement.executeUpdate();
+			if (no_updated == 1) { 
+				response.getOutputStream().print("OK!");
+			} else {
+				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to deactivate user.");
+			}
 
 
-    }
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
 
-    }
+	}
+
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
+
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
+
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/DeleteSaveGame.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/DeleteSaveGame.java
@@ -1,22 +1,20 @@
-/**********************************************************************
- Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
- Copyright (C) 2009-2016  The Freeciv-web project
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
- ***********************************************************************/
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -36,92 +34,99 @@ import javax.sql.DataSource;
 
 /**
  * Deletes a savegame.
+ *
+ * URL: /deletesavegame
  */
 public class DeleteSaveGame extends HttpServlet {
-    private static final long serialVersionUID = 1L;
-    private String PATTERN_VALIDATE_ALPHA_NUMERIC = "[0-9a-zA-Z\\.]*";
-    private Pattern p = Pattern.compile(PATTERN_VALIDATE_ALPHA_NUMERIC);
+	private static final long serialVersionUID = 1L;
+	private String PATTERN_VALIDATE_ALPHA_NUMERIC = "[0-9a-zA-Z\\.]*";
+	private Pattern p = Pattern.compile(PATTERN_VALIDATE_ALPHA_NUMERIC);
 
-    private String savegame_dir;
+	private String savegameDirectory;
 
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
 
-        try {
-            Properties prop = new Properties();
-            prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
-            savegame_dir = prop.getProperty("savegame_dir");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+		try {
+			Properties prop = new Properties();
+			prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
+			savegameDirectory = prop.getProperty("savegame_dir");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-        String username = request.getParameter("username");
-        String savegame = request.getParameter("savegame");
-        String password = java.net.URLDecoder.decode(request.getParameter("password"), "UTF-8");
+		String username = request.getParameter("username");
+		String savegame = request.getParameter("savegame");
+		String password = java.net.URLDecoder.decode(request.getParameter("password"), "UTF-8");
 
-        if (!p.matcher(username).matches() || username.toLowerCase().equals("pbem")) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    "Invalid username");
-            return;
-        }
-        if (savegame == null || savegame.length() > 100 || savegame.contains(".") || savegame.contains("/") || savegame.contains("\\")) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    "Invalid savegame");
-            return;
-        }
+		if (!p.matcher(username).matches() || username.toLowerCase().equals("pbem")) {
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+					"Invalid username");
+			return;
+		}
+		if (savegame == null || savegame.length() > 100 || savegame.contains(".") || savegame.contains("/") || savegame.contains("\\")) {
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+					"Invalid savegame");
+			return;
+		}
 
-        Connection conn = null;
-        try {
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
+		Connection conn = null;
+		try {
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
 
-            String pwdSQL = "SELECT count(*) from auth where lower(username) = lower(?) and password = MD5(?) and activated='1'";
-            PreparedStatement preparedStatement = conn.prepareStatement(pwdSQL);
-            preparedStatement.setString(1, username);
-            preparedStatement.setString(2, password);
-            ResultSet rs = preparedStatement.executeQuery();
-            rs.next();
-            if (rs.getInt(1) != 1) {
-                /* Invalid password*/
-                return;
-            }
+			String query =
+					  "SELECT count(*) "
+					+ "FROM auth "
+					+ "WHERE LOWER(username) = LOWER(?) "
+					+ "	AND password = MD5(?) "
+					+ "	AND activated = '1' ";
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			preparedStatement.setString(1, username);
+			preparedStatement.setString(2, password);
+			ResultSet rs = preparedStatement.executeQuery();
+			rs.next();
+			if (rs.getInt(1) != 1) {
+				// user not found or deactivated
+				return;
+			}
 
-        } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
 
-        try {
-            File savegameFile = new File(savegame_dir + username + "/" + savegame + ".sav.xz");
-            if (savegameFile.exists() && savegameFile.isFile() && savegameFile.getName().endsWith(".sav.xz")) {
-                Files.delete(savegameFile.toPath());
-            }
-        } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "ERROR");
-        }
+		try {
+			File savegameFile = new File(savegameDirectory + username + "/" + savegame + ".sav.xz");
+			if (savegameFile.exists() && savegameFile.isFile() && savegameFile.getName().endsWith(".sav.xz")) {
+				Files.delete(savegameFile.toPath());
+			}
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "ERROR");
+		}
 
-    }
+	}
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-    }
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
+
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/FreecivStatsServlet.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/FreecivStatsServlet.java
@@ -1,9 +1,28 @@
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -13,82 +32,66 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
-
-
 /**
  * This servlet will collect statistics about time played, and number of games stated.
+ *
+ * URL: /freeciv_time_played_stats
  */
 public class FreecivStatsServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
-	
-	  @SuppressWarnings("unchecked")
-	    public void doPost(HttpServletRequest request, HttpServletResponse response)
-	            throws IOException, ServletException {
 
-	       Connection conn = null;
-	        try {
+	private final static Map<String, Integer> gameTypes = new HashMap<>();
+	static {
+		gameTypes.put("single2d", 0);
+		gameTypes.put("single3d", 5);
+		gameTypes.put("multi", 1);
+		gameTypes.put("pbem", 2);
+		gameTypes.put("hotseat", 4);
+	}
 
-	        	String type = request.getParameter("type");
-	        	if (type == null) return;
-	        	
-	            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-	            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-	            conn = ds.getConnection();
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-				switch (type) {
-					case "single2d": {
-						String insertTableSQL = "INSERT INTO games_played_stats (statsDate, gameType, gameCount) VALUES (CURDATE(), 0, 1)  ON DUPLICATE KEY UPDATE gameCount = gameCount + 1";
-						PreparedStatement preparedStatement = conn.prepareStatement(insertTableSQL);
-						preparedStatement.executeUpdate();
-						break;
-					}
-					case "single3d": {
-						String insertTableSQL = "INSERT INTO games_played_stats (statsDate, gameType, gameCount) VALUES (CURDATE(), 5, 1)  ON DUPLICATE KEY UPDATE gameCount = gameCount + 1";
-						PreparedStatement preparedStatement = conn.prepareStatement(insertTableSQL);
-						preparedStatement.executeUpdate();
-						break;
-					}
-					case "multi": {
-						String insertTableSQL = "INSERT INTO games_played_stats (statsDate, gameType, gameCount) VALUES (CURDATE(), 1, 1)  ON DUPLICATE KEY UPDATE gameCount = gameCount + 1";
-						PreparedStatement preparedStatement = conn.prepareStatement(insertTableSQL);
-						preparedStatement.executeUpdate();
-						break;
-					}
-					case "pbem": {
-						String insertTableSQL = "INSERT INTO games_played_stats (statsDate, gameType, gameCount) VALUES (CURDATE(), 2, 1)  ON DUPLICATE KEY UPDATE gameCount = gameCount + 1";
-						PreparedStatement preparedStatement = conn.prepareStatement(insertTableSQL);
-						preparedStatement.executeUpdate();
+		Connection conn = null;
+		try {
 
-						break;
-					}
-					case "hotseat": {
-						String insertTableSQL = "INSERT INTO games_played_stats (statsDate, gameType, gameCount) VALUES (CURDATE(), 4, 1)  ON DUPLICATE KEY UPDATE gameCount = gameCount + 1";
-						PreparedStatement preparedStatement = conn.prepareStatement(insertTableSQL);
-						preparedStatement.executeUpdate();
+			String gameType = request.getParameter("type");
+			if (!gameTypes.containsKey(gameType)) {
+				return;
+			}
 
-						break;
-					}
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
+
+			int gameTypeId = gameTypes.get(gameType);
+
+			String insert =
+							  "INSERT INTO games_played_stats (statsDate, gameType, gameCount) "
+							+ "VALUES (CURDATE(), ?, 1) "
+							+ "ON DUPLICATE KEY UPDATE gameCount = gameCount + 1";
+			PreparedStatement preparedStatement = conn.prepareStatement(insert);
+			preparedStatement.setInt(1, gameTypeId);
+			preparedStatement.executeUpdate();
+
+
+		} catch (Exception err) {
+			System.err.println("Error in FreecivStatsServlet" + err.getMessage());
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
 				}
+		}
 
-	            
+	}
 
-	      } catch (Exception err) {
-				System.err.println("Error in FreecivStatsServlet" + err.getMessage());
-	      } finally {
-	            if (conn != null)
-	                try {
-	                    conn.close();
-	                } catch (SQLException e) {
-	                    e.printStackTrace();
-	                }
-	        }
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-
-	    }
-
-	    public void doGet(HttpServletRequest request, HttpServletResponse response)
-	            throws IOException, ServletException {
-	        response.getOutputStream().print("Sorry");
-
-	    }
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
+		
+	}
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/ListSaveGames.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/ListSaveGames.java
@@ -1,22 +1,20 @@
-/**********************************************************************
- Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
- Copyright (C) 2009-2016  The Freeciv-web project
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
- ***********************************************************************/
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -30,70 +28,73 @@ import javax.servlet.http.*;
 
 /**
  * Returns a list of savegames for the given user
+ *
+ * URL: /listsavegames
  */
 public class ListSaveGames extends HttpServlet {
-    private static final long serialVersionUID = 1L;
-    private String PATTERN_VALIDATE_ALPHA_NUMERIC = "[0-9a-zA-Z\\.]*";
-    private Pattern p = Pattern.compile(PATTERN_VALIDATE_ALPHA_NUMERIC);
+	private static final long serialVersionUID = 1L;
+	private String PATTERN_VALIDATE_ALPHA_NUMERIC = "[0-9a-zA-Z\\.]*";
+	private Pattern p = Pattern.compile(PATTERN_VALIDATE_ALPHA_NUMERIC);
 
-    private String savegame_dir;
+	private String savegameDirectory;
 
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
 
-        try {
-            Properties prop = new Properties();
-            prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
-            savegame_dir = prop.getProperty("savegame_dir");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+		try {
+			Properties prop = new Properties();
+			prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
+			savegameDirectory = prop.getProperty("savegame_dir");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-        String username = request.getParameter("username");
-        if (!p.matcher(username).matches()) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    "Invalid username");
-            return;
-        }
+		String username = request.getParameter("username");
+		if (username != null && !p.matcher(username).matches()) {
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+					"Invalid username");
+			return;
+		}
 
-        try {
-            File folder = new File(savegame_dir + "/" + username);
+		try {
+			File folder = new File(savegameDirectory + "/" + username);
 
-            if (!folder.exists()) {
-                response.getOutputStream().print(";");
-            } else {
-                File[] files = folder.listFiles();
-                Arrays.sort(files, new Comparator<File>() {
-                    public int compare(File f1, File f2) {
-                        return Long.compare(f1.lastModified(), f2.lastModified());
-                    }
-                });
-                String result = "";
-                for (int i = 0; i < files.length; i++) {
-                    if (files[i].isFile()) {
-                        result += files[i].getName().replaceAll(".sav.xz", "") + ";";
-                    }
-                }
-                response.getOutputStream().print(result);
-            }
+			if (!folder.exists()) {
+				response.getOutputStream().print(";");
+			} else {
+				File[] files = folder.listFiles();
+				Arrays.sort(files, new Comparator<File>() {
+					public int compare(File f1, File f2) {
+						return Long.compare(f1.lastModified(), f2.lastModified());
+					}
+				});
+				StringBuffer buffer = new StringBuffer();
+				for (File file : files) {
+					if (file.isFile()) {
+						buffer.append(file.getName().replaceAll(".sav.xz", ""));
+						buffer.append(';');
+					}
+				}
+				response.getOutputStream().print(buffer.toString());
+			}
 
-        } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "ERROR");
-        }
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "ERROR");
+		}
 
-    }
+	}
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-    }
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
+
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/NewPBEMUser.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/NewPBEMUser.java
@@ -1,23 +1,20 @@
-/**********************************************************************
-    Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
-    Copyright (C) 2009-2015  The Freeciv-web project
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-***********************************************************************/
-
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.util.ArrayList;
@@ -45,111 +42,117 @@ import javax.naming.*;
 
 
 /**
- * creates a new play by email user account.
+ * Creates a new play by email user account.
+ *
+ * URL: /create_pbem_user
  */
 public class NewPBEMUser extends HttpServlet {
-    private static final long serialVersionUID = 1L;
-    private String captcha_secret;
 
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
+	private static final int ACTIVATED = 1;
+	private static final long serialVersionUID = 1L;
+	private String captchaSecret;
 
-        try {
-            Properties prop = new Properties();
-            prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
-            captcha_secret = prop.getProperty("captcha_secret");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-    
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
 
-        String username = java.net.URLDecoder.decode(request.getParameter("username"), "UTF-8");
-        String password = java.net.URLDecoder.decode(request.getParameter("password"), "UTF-8");
-        String email = java.net.URLDecoder.decode(request.getParameter("email"), "UTF-8");
-        String captcha = java.net.URLDecoder.decode(request.getParameter("captcha"), "UTF-8");
+		try {
+			Properties prop = new Properties();
+			prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
+			captchaSecret = prop.getProperty("captcha_secret");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-        if (password == null || password.length() <= 2) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "Invalid password. Please try again with another password.");
-            return;
-        }
-        if (username == null || username.length() <= 2) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "Invalid username. Please try again with another username.");
-            return;
-        }
-        if (email == null || email.length() <= 4) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "Invalid e-mail address. Please try again with another username.");
-            return;
-        }
-    	HttpClient client = HttpClientBuilder.create().build();
-        String captcha_url = "https://www.google.com/recaptcha/api/siteverify";
-        HttpPost post = new HttpPost(captcha_url);
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-    	List<NameValuePair> urlParameters = new ArrayList<>();
-    	urlParameters.add(new BasicNameValuePair("secret", captcha_secret));
-    	urlParameters.add(new BasicNameValuePair("response", captcha));
-    	post.setEntity(new UrlEncodedFormEntity(urlParameters));
+		String username = java.net.URLDecoder.decode(request.getParameter("username"), "UTF-8");
+		String password = java.net.URLDecoder.decode(request.getParameter("password"), "UTF-8");
+		String email = java.net.URLDecoder.decode(request.getParameter("email"), "UTF-8");
+		String captcha = java.net.URLDecoder.decode(request.getParameter("captcha"), "UTF-8");
 
-        if (!captcha_secret.contains("secret goes here")) {
-          /* Validate captcha against google api. skip validation for localhost 
+		if (password == null || password.length() <= 2) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+					"Invalid password. Please try again with another password.");
+			return;
+		}
+		if (username == null || username.length() <= 2) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+					"Invalid username. Please try again with another username.");
+			return;
+		}
+		if (email == null || email.length() <= 4) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+					"Invalid e-mail address. Please try again with another username.");
+			return;
+		}
+		HttpClient client = HttpClientBuilder.create().build();
+		String captchaUrl = "https://www.google.com/recaptcha/api/siteverify";
+		HttpPost post = new HttpPost(captchaUrl);
+
+		List<NameValuePair> urlParameters = new ArrayList<>();
+		urlParameters.add(new BasicNameValuePair("secret", captchaSecret));
+		urlParameters.add(new BasicNameValuePair("response", captcha));
+		post.setEntity(new UrlEncodedFormEntity(urlParameters));
+
+		if (!captchaSecret.contains("secret goes here")) {
+			/* Validate captcha against google api. skip validation for localhost 
              where captcha_secret still has default value. */
-          HttpResponse captcha_response = client.execute(post);
-          InputStream in = captcha_response.getEntity().getContent();
-          String body = IOUtils.toString(in, "UTF-8");
-    	  if (!(body.contains("success") && body.contains("true"))) {
-    		response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Captcha failed!");
-    		return;
-    	  }
-       }
+			HttpResponse captchaResponse = client.execute(post);
+			InputStream in = captchaResponse.getEntity().getContent();
+			String body = IOUtils.toString(in, "UTF-8");
+			if (!(body.contains("success") && body.contains("true"))) {
+				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Captcha failed!");
+				return;
+			}
+		}
 
-       Connection conn = null;
-        try {
-            Thread.sleep(300);
+		Connection conn = null;
+		try {
+			Thread.sleep(300);
 
-            String ipAddress = request.getHeader("X-Real-IP");  
-            if (ipAddress == null) {  
-              ipAddress = request.getRemoteAddr();  
-            }
+			String ipAddress = request.getHeader("X-Real-IP");  
+			if (ipAddress == null) {  
+				ipAddress = request.getRemoteAddr();  
+			}
 
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
 
- 
-            String insertTableSQL = "INSERT INTO auth (username, email, password, activated, ip) VALUES (?,?, MD5(?), ?, ?)";
-            PreparedStatement preparedStatement = conn.prepareStatement(insertTableSQL);
-            preparedStatement.setString(1, username.toLowerCase());
-            preparedStatement.setString(2, email);
-            preparedStatement.setString(3, password);
-            preparedStatement.setInt(4, 1);
-            preparedStatement.setString(5, ipAddress);
-            preparedStatement.executeUpdate();
 
-      } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to create user: " + err);
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
+			String query =
+					"INSERT INTO auth (username, email, password, activated, ip) "
+							+ "VALUES (?,?, MD5(?), ?, ?)";
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			preparedStatement.setString(1, username.toLowerCase());
+			preparedStatement.setString(2, email);
+			preparedStatement.setString(3, password);
+			preparedStatement.setInt(4, ACTIVATED);
+			preparedStatement.setString(5, ipAddress);
+			preparedStatement.executeUpdate();
 
-    }
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to create user: " + err);
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
+	}
 
-    }
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
+
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
+
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/RandomUser.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/RandomUser.java
@@ -1,23 +1,20 @@
-/**********************************************************************
-    Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
-    Copyright (C) 2009-2015  The Freeciv-web project
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-***********************************************************************/
-
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -31,50 +28,55 @@ import javax.naming.*;
 
 
 /**
- * Finds a random opponent username 
+ * Finds a random opponent username.
+ *
+ * URL: /random_user
  */
 public class RandomUser extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-       Connection conn = null;
-        try {
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
+		Connection conn = null;
+		try {
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
 
-            String pwdSQL = "SELECT username FROM `auth` WHERE activated='1' and id >= (SELECT FLOOR( MAX(id) * RAND()) FROM `auth` ) ORDER BY id LIMIT 1;";
-            PreparedStatement preparedStatement = conn.prepareStatement(pwdSQL);
-            ResultSet rs = preparedStatement.executeQuery();
-            if (rs.next()) {
-              response.getOutputStream().print(rs.getString(1));
-              return;
-            }
+			String query =
+					  "SELECT username "
+					+ "FROM `auth` "
+					+ "WHERE activated='1' "
+					+ "	AND id >= (SELECT FLOOR(MAX(id) * RAND()) FROM `auth`) "
+					+ "ORDER BY id LIMIT 1;";
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			ResultSet rs = preparedStatement.executeQuery();
+			if (!rs.next()) {
+				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid user.");
+				return;
+			}
+			response.getOutputStream().print(rs.getString(1));
 
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid user.");
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
+	}
 
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-      } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
-    }
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
-
-    }
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/UserCount.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/UserCount.java
@@ -1,23 +1,20 @@
-/**********************************************************************
-    Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
-    Copyright (C) 2009-2015  The Freeciv-web project
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-***********************************************************************/
-
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -32,47 +29,49 @@ import javax.naming.*;
 
 /**
  * Counts number of users.
+ *
+ * URL: /user_count
  */
 public class UserCount extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-       Connection conn = null;
-        try {
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
+		Connection conn = null;
+		try {
 
-            String countSQL = "SELECT count(*) FROM `auth`";
-            PreparedStatement preparedStatement = conn.prepareStatement(countSQL);
-            ResultSet rs = preparedStatement.executeQuery();
-            if (rs.next()) {
-              response.getOutputStream().print(rs.getString(1));
-            }
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
 
-      } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to count users");
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
+			String query = "SELECT COUNT(*) FROM `auth`";
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			ResultSet rs = preparedStatement.executeQuery();
+			if (rs.next()) {
+				response.getOutputStream().print(rs.getString(1));
+			}
 
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to count users");
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
+		
+	}
 
-    }
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
 
-    }
+	}
 
 }

--- a/freeciv-web/src/main/java/org/freeciv/servlet/ValidateUser.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/ValidateUser.java
@@ -1,23 +1,20 @@
-/**********************************************************************
-    Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
-    Copyright (C) 2009-2015  The Freeciv-web project
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-***********************************************************************/
-
-
+/*******************************************************************************
+ * Freeciv-web - the web version of Freeciv. http://play.freeciv.org/
+ * Copyright (C) 2009-2017 The Freeciv-web project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
 package org.freeciv.servlet;
 
 import java.io.*;
@@ -31,63 +28,71 @@ import javax.naming.*;
 
 
 /**
- * Checks if a user with this username exists. 
+ * Given a username or an email address it verifies
+ * if it matches a user in the database.
+ *
+ * URL: /validate_user
  */
 public class ValidateUser extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unchecked")
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
 
-       String userstring = request.getParameter("userstring");
+		String usernameOrEmail = request.getParameter("userstring");
 
-       Connection conn = null;
-        try {
-            Context env = (Context) (new InitialContext().lookup("java:comp/env"));
-            DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
-            conn = ds.getConnection();
+		Connection conn = null;
+		try {
 
-            String usrSQL = "SELECT username, activated from auth where lower(username) = lower(?) or lower(email) = lower(?)";
-            PreparedStatement preparedStatement = conn.prepareStatement(usrSQL);
-            preparedStatement.setString(1, userstring);
-            preparedStatement.setString(2, userstring);
-            ResultSet rs = preparedStatement.executeQuery();
-            if (rs.next()) {
-              String username = rs.getString(1);
-              int activated = rs.getInt(2);
-              if (activated == 1) {
-                response.getOutputStream().print(username);
-              } else {
-                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid user");
-              }
-  
-            } else if (userstring != null && userstring.contains("@")) {
-                response.getOutputStream().print("invitation");
-            } else {
-                response.getOutputStream().print("user_does_not_exist");
-            }
+			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
+			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
+			conn = ds.getConnection();
 
-      } catch (Exception err) {
-            response.setHeader("result", "error");
-            err.printStackTrace();
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
-        } finally {
-            if (conn != null)
-                try {
-                    conn.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-        }
+			String query =
+					  "SELECT username, activated "
+					+ "FROM auth "
+					+ "WHERE LOWER(username) = LOWER(?) "
+					+ "	OR LOWER(email) = LOWER(?)";
 
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			preparedStatement.setString(1, usernameOrEmail);
+			preparedStatement.setString(2, usernameOrEmail);
+			ResultSet rs = preparedStatement.executeQuery();
 
-    }
+			if (rs.next()) {
+				String username = rs.getString(1);
+				int activated = rs.getInt(2);
+				if (activated == 1) {
+					response.getOutputStream().print(username);
+				} else {
+					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid user");
+				}
+			} else if (usernameOrEmail != null && usernameOrEmail.contains("@")) {
+				response.getOutputStream().print("invitation");
+			} else {
+				response.getOutputStream().print("user_does_not_exist");
+			}
 
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
-        response.getOutputStream().print("Sorry");
+		} catch (Exception err) {
+			response.setHeader("result", "error");
+			err.printStackTrace();
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to login");
+		} finally {
+			if (conn != null)
+				try {
+					conn.close();
+				} catch (SQLException e) {
+					e.printStackTrace();
+				}
+		}
 
-    }
+	}
+
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException {
+
+		response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "This endpoint only supports the POST method.");
+
+	}
 
 }


### PR DESCRIPTION
Github can ignore [whitespace](https://github.com/blog/967-github-secrets) when showing diffs. It might be useful when reviewing this pull request.

I used [Eclipse Copyright Tool](https://wiki.eclipse.org/Development_Resources/How_to_Use_Eclipse_Copyright_Tool) to fix the licences. It altered a bit the existing formatting, but on the other side it ensures that no file is forgotten.

Changes:
* Updated copyright dates
* Added license where license was missing.
* Removed useless @SuppressWarnings("unchecked")
* Replaced complex if condition with switch in CivclientLauncher
* Shortened long lines for easier readability on smaller screens
* Instead of building the query by concatenating strings now we use statement.setString
* Reply with 405 when using the GET method instead of 200.
* Renamed some variables to be compliant with Java conventions.
* Indented code. Please ignore whitespaces for more readable diff (-w)
* Removed duplicate code where possible. (see stats servlet)