### PR TITLE
JSHint cleanups

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/2dcanvas/mapctrl.js
+++ b/freeciv-web/src/main/webapp/javascript/2dcanvas/mapctrl.js
@@ -55,7 +55,7 @@ function mapview_mouse_click(e)
   var rightclick = false;
   var middleclick = false;
 
-  if (!e) var e = window.event;
+  if (!e) e = window.event;
   if (e.which) {
     rightclick = (e.which == 3);
     middleclick = (e.which == 2);
@@ -90,7 +90,7 @@ function mapview_mouse_down(e)
   var rightclick = false;
   var middleclick = false;
 
-  if (!e) var e = window.event;
+  if (!e) e = window.event;
   if (e.which) {
     rightclick = (e.which == 3);
     middleclick = (e.which == 2);
@@ -197,7 +197,7 @@ function mapview_touch_move(e)
 function city_mapview_mouse_click(e)
 {
   var rightclick;
-  if (!e) var e = window.event;
+  if (!e) e = window.event;
   if (e.which) {
     rightclick = (e.which == 3);
   } else if (e.button) {
@@ -392,7 +392,6 @@ function update_active_units_dialog()
 
   for (var i = 0; i < punits.length; i++) {
     var punit = punits[i];
-    var ptype = unit_type(punit);
     var sprite = get_unit_image_sprite(punit);
     var active = (current_focus.length > 1 || current_focus[0]['id'] == punit['id']);
 
@@ -411,18 +410,18 @@ function update_active_units_dialog()
     var aunit = current_focus[0];
     var ptype = unit_type(aunit);
     unit_info_html += "<div id='active_unit_info' title='" + ptype['helptext'] + "'>";
-    unit_info_html += "<b>" + ptype['name'] + "</b>: "
-    if (get_unit_homecity_name(punit) != null) {
-      unit_info_html += " " + get_unit_homecity_name(punit) + " ";
+    unit_info_html += "<b>" + ptype['name'] + "</b>: ";
+    if (get_unit_homecity_name(aunit) != null) {
+      unit_info_html += " " + get_unit_homecity_name(aunit) + " ";
     }
-    unit_info_html += "<span>" + get_unit_moves_left(punit) + "</span> ";
+    unit_info_html += "<span>" + get_unit_moves_left(aunit) + "</span> ";
     unit_info_html += "<br><span title='Attack strength'>A:" + ptype['attack_strength']
     + "</span> <span title='Defense strength'>D:" + ptype['defense_strength']
     + "</span> <span title='Firepower'>F:" + ptype['firepower']
     + "</span> <span title='Health points'>H:"
     + ptype['hp'] + "</span>";
-    if (punit['veteran'] > 0) {
-      unit_info_html += " <span>Veteran: " + punit['veteran'] + "</span>";
+    if (aunit['veteran'] > 0) {
+      unit_info_html += " <span>Veteran: " + aunit['veteran'] + "</span>";
     }
     if (ptype['transport_capacity'] > 0) {
       unit_info_html += " <span>Transport: " + ptype['transport_capacity'] + "</span>";


### PR DESCRIPTION
WIP for https://github.com/freeciv/freeciv-web/issues/30 (just starting to get the hang of this, don't hold your breath).
Removes (most) JSHint warnings for 2dcanvas/mapctrl.js.
Uncovers and solves a real bug in units window that showed some info from the last unit in the stack, instead of the active one.

To clean the other two warnings, I'd have to rename the variables for their respective blocks or move their declarations to the outer function block. Or use [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) instead of `var`, which I think may be The Right Way (block scope instead of function scope), but that's ES6, JSHint warns with `'let' is available in ES6 (use esnext option) or Mozilla JS extensions (use moz).`, and I don't know what freeciv-web targets and how to change it, if at all. Also, I found out about let when preparing this change (did I say I'm a novice and whatever I contribute must be thoroughly reviewed?)