### PR TITLE
include bold, italic variants of Open Sans font

### DIFF
--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/head.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/head.jsp
@@ -14,7 +14,7 @@
 <link href="/static/css/bootstrap.min.css" rel="stylesheet">
 <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-<link href="https://fonts.googleapis.com/css?family=Open+Sans|Fredericka+the+Great" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Fredericka+the+Great|Open+Sans:400,400i,700,700i" rel="stylesheet">
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Currently bold text isn't well differentiated on the website because only the regular (400) variant of "Open Sans" is included. This will include the bold (700), italic (400i) and bold italic (700i) variants.

Example of bold text, almost indistinguishable:
![image](https://cloud.githubusercontent.com/assets/1050936/26498826/f81a7c50-41f5-11e7-8c68-29faae05c53f.png)

