### PR TITLE
Unzip mysql-connector with -o

### DIFF
--- a/scripts/vagrant-build.sh
+++ b/scripts/vagrant-build.sh
@@ -81,7 +81,7 @@ pip3 install wikipedia
 ## build and install mysql-connector-python
 cd /tmp
 wget https://github.com/mysql/mysql-connector-python/archive/2.1.3.zip
-unzip 2.1.3.zip
+unzip -qo 2.1.3.zip
 cd mysql-connector-python-2.1.3
 python3 setup.py install
 


### PR DESCRIPTION
Fixes crash when trying to reinstall after a previously failed install.