### PR TITLE
Vagrant provisioning enhancement for new boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--memory", mem]
   end
 
-  config.vm.synced_folder "./", "/vagrant"
+  # workaround vbox bug 16670
+  config.vm.synced_folder "./", "/vagrant", disabled: true
+  config.vm.provision :shell, :path => "scripts/vbox-workaround-16670.sh", run: "always"
 
   # run the Freeciv bootstrap script on startup
   config.vm.provision :shell, :path => "scripts/vagrant-build.sh", run: "always"

--- a/scripts/vagrant-build.sh
+++ b/scripts/vagrant-build.sh
@@ -28,8 +28,9 @@ echo "================================="
 echo "Running Freeciv-web setup script."
 echo "================================="
 
-# if Freeciv-web already built with Vagrant, then start it instead.
-if [ -f "/vagrant/freeciv-web/target/freeciv-web.war" ]; then
+# if system already provisioned and Freeciv-web already built with Vagrant,
+# then start it instead.
+if [ -f "/usr/sbin/nginx" -a -f "/vagrant/freeciv-web/target/freeciv-web.war" ]; then
   printf "\n\nFreeciv-web already built, starting it.\n\n-----";
   cd ${basedir}/scripts/ && sudo -H -u ubuntu ./start-freeciv-web.sh
   printf "Freeciv-web started. Now login with 'vagrant ssh' and point your browser to http://localhost";

--- a/scripts/vbox-workaround-16670.sh
+++ b/scripts/vbox-workaround-16670.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Detect and correct bug in vbox guest additions 5.1.20
+# See https://www.virtualbox.org/ticket/16670
+
+[ -e "/sbin/mount.vboxsf" ] || sudo ln -sf /opt/VBoxGuestAdditions-5.1.20/lib/VBoxGuestAdditions/mount.vboxsf /sbin/mount.vboxsf
+mount -t vboxsf -o uid=`id -u ubuntu`,gid=`id -g ubuntu` vagrant /vagrant


### PR DESCRIPTION
Add a workaround for a bug in virtualbox guest additions 5.1.20 and a fix to provision new boxes after having used another one (both triggered after destroying previous yakkety and downloading new zesty).