### PR TITLE
Bring apostrophes and other characters back to the message box

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -354,15 +354,27 @@ function update_mouse_cursor()
 }
 
 /****************************************************************************
+ Common replacements and encoding for messages.
+ They are going to be injected as html. " and ' are changed to appease
+ the server message_escape.patch until it is removed.
+****************************************************************************/
+function encode_message_text(message) {
+  message = message.replace(/^\s+|\s+$/g,"");
+  message = message.replace(/&/g, "&amp;");
+  message = message.replace(/'/g, "&apos;");
+  message = message.replace(/"/g, "&quot;");
+  message = message.replace(/</g, "&lt;");
+  message = message.replace(/>/g, "&gt;");
+  return encodeURIComponent(message);
+}
+
+/****************************************************************************
 ...
 ****************************************************************************/
 function check_text_input(event,chatboxtextarea) {
 
   if (event.keyCode == 13 && event.shiftKey == 0)  {
-    var message = $(chatboxtextarea).val();
-    message = message.replace(/^\s+|\s+$/g,"");
-    message = message.replace("'", "");
-    message = encodeURIComponent(message);
+    var message = encode_message_text($(chatboxtextarea).val());
 
     $(chatboxtextarea).val('');
     if (!is_touch_device()) $(chatboxtextarea).focus();

--- a/freeciv-web/src/main/webapp/javascript/nation.js
+++ b/freeciv-web/src/main/webapp/javascript/nation.js
@@ -340,6 +340,20 @@ function center_on_player()
 }
 
 /**************************************************************************
+  Send a private message to another human player from the dialog.
+  Only called from within the dialog.
+**************************************************************************/
+function send_private_message(other_player_name)
+{
+  var message = other_player_name + ": " + encode_message_text($("#private_message_text").val());
+  var packet = {"pid" : packet_chat_msg_req,
+                "message" : message};
+  send_request(JSON.stringify(packet));
+  keyboard_input = true;
+  $("#dialog").dialog('close');
+}
+
+/**************************************************************************
   Show the dialog for sending a private message to another human player.
 **************************************************************************/
 function show_send_private_message_dialog()
@@ -369,13 +383,7 @@ function show_send_private_message_dialog()
 			buttons:
 			{
 				"Send" : function() {
-                          var message = name + ": " + encodeURIComponent($("#private_message_text").val());
-                          var packet = {"pid" : packet_chat_msg_req,
-                                          "message" : message};
-                          send_request(JSON.stringify(packet));
-
-                          keyboard_input = true;
-                          $("#dialog").dialog('close');
+				  send_private_message(name);
 				}
 			}
 		});
@@ -386,12 +394,7 @@ function show_send_private_message_dialog()
 
   $('#dialog').keyup(function(e) {
     if (e.keyCode == 13) {
-      var message = name + ": " + encodeURIComponent($("#private_message_text").val());
-      var packet = {"pid" : packet_chat_msg_req,
-                      "message" : message};
-      send_request(JSON.stringify(packet));
-      keyboard_input = true;
-      $("#dialog").dialog('close');
+      send_private_message(name);
     }
   });
 


### PR DESCRIPTION
Allows sending apostrophes in the text. The problem was different in two places:
- the chatbox would remove the first one, changing "it's" to "its", and the server would cut the message if there was a second one
- the new private message dialog didn't even remove them, so the server cut the message when it found one.

This patch makes both ways use the same escaping, and replaces the "bad" characters by their html entities. As the message is going to be injected as html, that should be enough.

Solves issue #69.