### PR TITLE
Keep order in cities tab and cities navigation

### DIFF
--- a/freeciv-web/src/main/webapp/css/civclient.css
+++ b/freeciv-web/src/main/webapp/css/civclient.css
@@ -918,7 +918,7 @@ button.fg-button {  width:auto; overflow:visible; } /* removes extra button widt
   width: 100%;
 }
 
-#cities_row {
+.cities_row {
   cursor:pointer; 
   cursor:hand;
 }

--- a/freeciv-web/src/main/webapp/javascript/city.js
+++ b/freeciv-web/src/main/webapp/javascript/city.js
@@ -863,26 +863,18 @@ function city_name_dialog(suggested_name, unit_id) {
 function next_city()
 {
   if (!client.conn.playing) return;
-  var city_id;
 
-  var is_next = false;
-  for (city_id in cities) {
-    var pcity = cities[city_id];
-    if (is_next && city_owner(pcity).playerno == client.conn.playing.playerno) {
-      show_city_dialog(pcity);
-      return;
-    }
-    if (active_city['id'] == city_id) {
-      is_next = true;
-    }
+  ensure_city_screen_is_updated();
+
+  var next_row = $('#cities_list_' + active_city['id']).next();
+  if (next_row.length === 0) {
+    // Either the city is not in the list anymore or it was the last item.
+    // Anyway, go to the beginning
+    next_row = $('#city_table tbody tr').first();
   }
-
-  for (city_id in cities) {
-    var scity = cities[city_id];
-    if (is_next && city_owner(scity).playerno == client.conn.playing.playerno) {
-      show_city_dialog(scity);
-      return;
-    }
+  if (next_row.length > 0) {
+    // If there's a city
+    show_city_dialog(cities[next_row.attr('id').substr(12)]);
   }
 }
 
@@ -893,24 +885,18 @@ function previous_city()
 {
   if (!client.conn.playing) return;
 
-  var prev_city = null;
-  for (var city_id in cities) {
-    var next_city = cities[city_id];
+  ensure_city_screen_is_updated();
 
-    if (prev_city != null && active_city['id'] == city_id
-        && city_owner(next_city).playerno == client.conn.playing.playerno) {
-      show_city_dialog(prev_city);
-      return;
-    }
-    if (city_owner(next_city).playerno == client.conn.playing.playerno) {
-      prev_city = next_city;
-    }
+  var prev_row = $('#cities_list_' + active_city['id']).prev();
+  if (prev_row.length === 0) {
+    // Either the city is not in the list anymore or it was the last item.
+    // Anyway, go to the end
+    prev_row = $('#city_table tbody tr').last();
   }
-  if (prev_city != null) {
-    show_city_dialog(prev_city);
+  if (prev_row.length > 0) {
+    // If there's a city
+    show_city_dialog(cities[prev_row.attr('id').substr(12)]);
   }
-
-
 }
 
 /**************************************************************************

--- a/freeciv-web/src/main/webapp/javascript/city.js
+++ b/freeciv-web/src/main/webapp/javascript/city.js
@@ -1374,7 +1374,7 @@ function update_city_screen()
         turns_to_complete_str = get_city_production_time(pcity) + " turns";
       }
 
-      city_list_html += "<tr id='cities_row' onclick='javascript:show_city_dialog_by_id(" + pcity['id'] + ");'><td>" 
+      city_list_html += "<tr class='cities_row' id='cities_list_" + pcity['id'] + "' onclick='javascript:show_city_dialog_by_id(" + pcity['id'] + ");'><td>"
               + pcity['name'] + "</td><td>" + numberWithCommas(city_population(pcity)*1000) +
               "</td><td>" + pcity['size'] + "</td><td>" + get_city_state(pcity) + "</td><td>" + pcity['food_stock'] + "/" + pcity['granary_size'] +
               "</td><td>" + city_turns_to_growth_text(pcity) + "</td>" + 

--- a/freeciv-web/src/main/webapp/javascript/city.js
+++ b/freeciv-web/src/main/webapp/javascript/city.js
@@ -1387,6 +1387,15 @@ function update_city_screen()
 
   if (observing) return;
 
+  var sortList = [];
+  var headers = $('#city_table thead td');
+  headers.filter('.tablesorter-headerAsc').each(function (i, cell) {
+    sortList.push([cell.cellIndex, 0]);
+  });
+  headers.filter('.tablesorter-headerDesc').each(function (i, cell) {
+    sortList.push([cell.cellIndex, 1]);
+  });
+
   var city_list_html = "<table class='tablesorter' id='city_table' border=0 cellspacing=0>"
         + "<thead><td>Name</td><td>Population</td><td>Size</td><td>State</td>"
         + "<td>Granary</td><td>Grows In</td><td>Producing</td>"  
@@ -1427,7 +1436,7 @@ function update_city_screen()
 
   $('#cities_scroll').css("height", $(window).height() - 200);
 
-  $("#city_table").tablesorter({theme:"dark"});
+  $("#city_table").tablesorter({theme:"dark", sortList: sortList});
 }
 
 /**************************************************************************

--- a/freeciv-web/src/main/webapp/javascript/packhand.js
+++ b/freeciv-web/src/main/webapp/javascript/packhand.js
@@ -318,6 +318,9 @@ function handle_web_city_info_addition(packet)
   if (renderer == RENDERER_WEBGL) {
     update_city_position(index_to_tile(packet['tile']));
   }
+
+  /* Update the cities info tab */
+  request_update_city_screen();
 }
 
 /* 99% complete
@@ -339,6 +342,9 @@ function handle_city_short_info(packet)
   if (renderer == RENDERER_WEBGL) {
     update_city_position(index_to_tile(packet['tile']));
   }
+
+  /* Update the cities info tab */
+  request_update_city_screen();
 }
 
 /**************************************************************************


### PR DESCRIPTION
These changes:
* Add the city id to the rows in the cities tab.
* Updates the cities tab when there are changes, instead of only when changing to that tab.
* Keep the cities tab order between updates.
* Use that order for the next/prev buttons in the city dialog.

Things to take into account:
* We just have the columns and direction by which the tabled is sorted, so when using several columns, this may not work. For example, sorting by production and granary will give you a table sorted by granary and production instead in the next update.
* Navigation from the city dialog calculates next and previous cities in the moment next/prev is clicked, not when the dialog was first open. That gives us new cities, removes lost cities and has all the other updates. So, if you wanted to sort by production to change all the cities building tanks to build currency, changing production in the first one will change its position in the table and when pressing next you won't get what you expected for this use case.