### PR TITLE
Show correct FPT in city dialog minimap.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
+++ b/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
@@ -360,14 +360,14 @@ function fill_sprite_array(layer, ptile, pedge, pcorner, punit, pcity, citymode)
 
       if (active_city != null && ptile != null && ptile['worked'] != null
           && active_city['id'] == ptile['worked'] && active_city['food_output'] != null) {
-	var dx = city_tile(active_city)['x'] - ptile['x'];
-	var dy = city_tile(active_city)['y'] - ptile['y'];
-
+        var ctile = city_tile(active_city);
+	var dx = ctile['x'] - ptile['x'];
+	var dy = ctile['y'] - ptile['y'];
         //this is a quick-fix for showing city workers correctly near map edges.
         if (dx > 4) dx -= map['xsize']; 
         if (dx < -4) dx += map['xsize'];
 
-        var idx = get_city_dxy_to_index(dx, dy);
+        var idx = get_city_dxy_to_index(dx, dy, ctile);
 	var food_output = active_city['food_output'].substring(idx, idx + 1);
 	var shield_output = active_city['shield_output'].substring(idx, idx + 1);
 	var trade_output = active_city['trade_output'].substring(idx, idx + 1);

--- a/freeciv-web/src/main/webapp/javascript/city.js
+++ b/freeciv-web/src/main/webapp/javascript/city.js
@@ -944,7 +944,7 @@ function city_turns_to_growth_text(pcity)
   Converts from coordinate offset from city center (dx, dy),
   to index in the city_info['food_output'] packet.
 **************************************************************************/
-function get_city_dxy_to_index(dx, dy)
+function get_city_dxy_to_index(dx, dy, ctile)
 {
   city_tile_map = {};
   city_tile_map[" 00"] = 0;
@@ -969,7 +969,30 @@ function get_city_dxy_to_index(dx, dy)
   city_tile_map[" -21"] = 19;
   city_tile_map[" -2-1"] = 20;
 
-  return city_tile_map[" "+dx+""+dy];
+  var idx = city_tile_map[" "+dx+""+dy];
+
+  var no_tiles = [];
+  switch (ctile.y) {
+  case 1:
+    no_tiles = [10, 15, 17];
+    break;
+  case (map.ysize - 2):
+    no_tiles = [11, 16, 18];
+    break;
+  case (map.ysize - 1):
+    no_tiles = [3, 6, 8, 11, 14, 16, 17, 20];
+    break;
+  case 0:
+    no_tiles = [2, 5, 7, 10, 13, 15, 17, 19];
+    break;
+  }
+
+  var le = no_tiles.length;
+  var correction = 0;
+  while (correction < le && no_tiles[correction] < idx) {
+    correction++;
+  }
+  return idx - correction;
 
 }
 


### PR DESCRIPTION
When the server sends food_output & co, only valid tiles are iterated (city_tile_iterate). That means near the poles we don't get the 21 tiles we expect for radius_sq = 5, but only 18 or 13. That makes the city dialog show incorrect info for some workers, and not draw others.

This patch makes the client aware of that. The Right Way to solve it may be to change the server code, though, to always send info for 21 tiles, with 0 output for invalid ones. Or better yet, make the client calculate it, as other clients do, and get rid of misc_devversion_sync.patch.

before:
![before](https://user-images.githubusercontent.com/13631068/27988487-418f0e60-6423-11e7-9815-5664d4fbb4b3.png)

after:
![after](https://user-images.githubusercontent.com/13631068/27988497-70684238-6423-11e7-952a-c309da91f81a.png)
