### PR TITLE
disable civil war in PBEM

### DIFF
--- a/publite2/pubscript_pbem.serv
+++ b/publite2/pubscript_pbem.serv
@@ -15,6 +15,7 @@ set landm 50
 set aifill 1
 set onsetbarbs 5000
 set barbarians disabled
+set civilwarsize 1000
 set minp 2
 set maxp 4
 set gold 500


### PR DESCRIPTION
Setting civilwarsize to 1000 to disable civil war and avoid creating AI players