### PR TITLE
Add "Build farmland" option to irrigate a second time

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -977,18 +977,25 @@ function update_unit_order_commands()
       if (tile_terrain(ptile)['name'] == "Forest") {
         $("#order_forest_remove").show();
         $("#order_irrigate").hide();
+        $("#order_build_farmland").hide();
 	    unit_actions["forest"] = {name: "Cut down forest (I)"};
       } else if (!tile_has_extra(ptile, EXTRA_IRRIGATION)) {
         $("#order_irrigate").show();
         $("#order_forest_remove").hide();
+        $("#order_build_farmland").hide();
         unit_actions["irrigation"] = {name: "Irrigation (I)"};
         if (tile_terrain(ptile)['name'] != 'Hills' && tile_terrain(ptile)['name'] != 'Mountains') {
           unit_actions["mine"] = {name: "Plant forest (M)"};
         }
+      } else if (!tile_has_extra(ptile, EXTRA_FARMLAND) && player_invention_state(client.conn.playing, tech_id_by_name('Refrigeration')) == TECH_KNOWN) {
+        $("#order_build_farmland").show();
+        $("#order_irrigate").hide();
+        $("#order_forest_remove").hide();
+        unit_actions["irrigation"] = {name: "Build farmland (I)"};
       } else {
         $("#order_forest_remove").hide();
         $("#order_irrigate").hide();
-
+        $("#order_build_farmland").hide();
       }
       if (player_invention_state(client.conn.playing, tech_id_by_name('Construction')) == TECH_KNOWN) {
         unit_actions["fortress"] = {name: string_unqualify(terrain_control['gui_type_base0']) + " (Shift-F)"};
@@ -1003,6 +1010,7 @@ function update_unit_order_commands()
       $("#order_railroad").hide();
       $("#order_mine").hide();
       $("#order_irrigate").hide();
+      $("#order_build_farmland").hide();
       $("#order_fortify").show();
       $("#order_auto_settlers").hide();
       $("#order_sentry").show();

--- a/freeciv-web/src/main/webapp/webclient/orders.jsp
+++ b/freeciv-web/src/main/webapp/webclient/orders.jsp
@@ -31,6 +31,10 @@
     <a href="#" onclick="key_unit_irrigate();"><img src="/images/orders/forest_remove_default.png" name="forest_remove_button" alt="" border="0" width="30" height="30"></a>
   </div>
 
+  <div id="order_build_farmland" class="order_button" title="Build farmland (I)" >
+    <a href="#" onclick="key_unit_irrigate();"><img src="/images/orders/irrigate_default.png" name="build_farmland_button" alt="" border="0" width="30" height="30"></a>
+  </div>
+
   <div id="order_road" class="order_button" title="Build road (R)">
     <a href="#" onclick="key_unit_road();"><img src="/images/orders/road_default.png" name="road_button" alt="" border="0" width="30" height="30"></a>
   </div>


### PR DESCRIPTION
Having discovered "Refrigeration" tech, one should be able to build farmlands on irrigated tiles, which is translate by the game as a second irrigation.

Currently, the only way to perform this action is by pressing the "I" shortcut for irrigation.

This pull-request adds a "Build Farmland" option in the options menu of a unit that can irrigate, and a "Build Farmland" button, which uses the default button for irrigation.