### PR TITLE
Introduce hack mode for web client only testing.

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/civclient.js
+++ b/freeciv-web/src/main/webapp/javascript/civclient.js
@@ -226,6 +226,37 @@ function init_common_intro_dialog() {
       show_intro_dialog("Welcome to Freeciv-web", msg);
     }
 
+  } else if ($.getUrlVar('action') == "hack") {
+    var hack_port;
+    var hack_username;
+
+    if ($.getUrlVar('civserverport') != null) {
+      hack_port = $.getUrlVar('civserverport');
+    } else {
+      show_intro_dialog("Welcome to Freeciv-web",
+        "Hack mode disabled because civserverport wasn't specified. "
+        + "Falling back to regular mode.");
+      return;
+    }
+
+    if ($.getUrlVar("username") != null) {
+      hack_username = $.getUrlVar("username");
+    } else if (simpleStorage.hasKey("username")) {
+      hack_username = simpleStorage.get("username");
+    } else {
+      show_intro_dialog("Welcome to Freeciv-web",
+        "Hack mode disabled because \"username\" wasn't specified and no "
+        + "stored user name was found. " +
+        "Falling back to regular mode.");
+      return;
+    }
+
+    if ($.getUrlVar('autostart') == "true") {
+      autostart = true;
+    }
+
+    network_init_manual_hack(hack_port, hack_username,
+                             $.getUrlVar("savegame"));
   } else {
     show_intro_dialog("Welcome to Freeciv-web",
       "You are about to join this game server, where you can " +

--- a/freeciv-web/src/main/webapp/javascript/clinet.js
+++ b/freeciv-web/src/main/webapp/javascript/clinet.js
@@ -33,6 +33,24 @@ var ping_last = new Date().getTime();
 var pingtime_check = 240000;
 var ping_timer = null;
 
+/**************************************************************************
+  Initialize the network communication with the server manually.
+**************************************************************************/
+function network_init_manual_hack(civserverport_manual, username_manual,
+                                  savegame)
+{
+  civserverport = civserverport_manual;
+  username = username_manual;
+
+  websocket_init();
+
+  if (savegame != null) {
+    wait_for_text("You are logged in as", function () {
+      load_game_real(savegame);
+    });
+  }
+}
+
 /****************************************************************************
   Initialized the Network communication, by requesting a valid server port.
 ****************************************************************************/

--- a/freeciv-web/src/main/webapp/javascript/packhand.js
+++ b/freeciv-web/src/main/webapp/javascript/packhand.js
@@ -79,7 +79,7 @@ function handle_server_join_reply(packet)
 
     set_client_state(C_S_PREPARING);
 
-    if ($.getUrlVar('action') == "new"
+    if (($.getUrlVar('action') == "new" || $.getUrlVar('action') == "hack")
         && $.getUrlVar('ruleset') != null) {
       change_ruleset($.getUrlVar('ruleset'));
     }


### PR DESCRIPTION
In addition to code for playing Freeciv in the web browser Freeciv-web
includes infastructure and code to administrate and run a big installation.
Stuff like the meta server and Freeciv servers dedicated to certain game
types are examples of this.

The big installation stuff isn't always needed. This applies both to
extremely small installations and to developers testing Freeciv-web changes
that don't touch the big installation infrastructure. An example of the
former are a single game with a few players that happens to be power users.
An example of the latter is a developer testing a change that only touches
the web client and/or the Freeciv server.

When I test changes to Freeciv-web I often log in using the same user name
before I load a test save game from a limited set or a ruleset. Doing this
manually often takes more time than testing the change it self. Being able to
jump straight into a test game would, at least for me, be extremely useful.

The Freeciv-web meta server is, at least in my set up, fragile. It has often
broken without leaving any clues that have enabled me to find out what is
wrong. Being able to bypass the Freeciv-web meta-server would allow me to
test changes to, and therefore work on, Freeciv-web in times when it is down.

Introduce a "hack" value to the "action" URL parameter. It takes the port of
the Freeciv server from the civserverport URL parameter rather than the meta
server. This allows many web client instances to connect to the same single
player server. It also allows connecting when the meta server refuses to
start. A hack mode game supports the URL parameters username, savegame,
ruleset and autostart. This makes it possible to bookmark a test case for
quick access.

Hack mode is written in browser side JavaScript. It should therefore not
cause any new security problems.