### PR TITLE
Keep trackjs token in config, like google signin key

### DIFF
--- a/freeciv-web/src/main/webapp/WEB-INF/config.properties.dist
+++ b/freeciv-web/src/main/webapp/WEB-INF/config.properties.dist
@@ -3,6 +3,7 @@ savegame_dir=/var/lib/tomcat8/webapps/data/savegames/
 email_username=username
 email_password=password
 google-signin-client-key=122428231951-2vrvrtd9sc2v9nktemclkvc2t187jkr6.apps.googleusercontent.com
+#trackjs-token=ee5dba6fe2e048f79b422157b450947b
 # Used in some messages and to distribute minimized or expanded js files,
 # so put the production server even when testing.
 fcw_host=example.com

--- a/freeciv-web/src/main/webapp/WEB-INF/config.properties.dist
+++ b/freeciv-web/src/main/webapp/WEB-INF/config.properties.dist
@@ -4,6 +4,5 @@ email_username=username
 email_password=password
 google-signin-client-key=122428231951-2vrvrtd9sc2v9nktemclkvc2t187jkr6.apps.googleusercontent.com
 #trackjs-token=ee5dba6fe2e048f79b422157b450947b
-# Used in some messages and to distribute minimized or expanded js files,
-# so put the production server even when testing.
+# Used in some messages, so put the production server even when testing.
 fcw_host=example.com

--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/head.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/head.jsp
@@ -1,3 +1,16 @@
+<%@ page import="static org.apache.commons.lang3.StringUtils.stripToNull" %>
+<%@ page import="java.util.Properties" %>
+<%@ page import="java.io.IOException" %>
+<%
+    String trackJsToken = null;
+    try {
+        Properties prop = new Properties();
+        prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
+        trackJsToken = stripToNull(prop.getProperty("trackjs-token"));
+    } catch (IOException e) {
+        e.printStackTrace();
+    }
+%>
 <title>${empty title ? "Freeciv-web - open source turn-based strategy game" : title}</title>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -26,9 +39,11 @@
 
 	ga('create', 'UA-40584174-1', 'auto');
 	ga('send', 'pageview');  
-</script> 
-<script src="https://d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js" data-token="ee5dba6fe2e048f79b422157b450947b"></script>
-
+</script>
+<% if (trackJsToken != null) { %>
+<script type="text/javascript">window._trackJs = { token: '<%= trackJsToken %>' };</script>
+<script type="text/javascript" src="https://cdn.trackjs.com/releases/current/tracker.js"></script>
+<% } %>
 <style>
 	/*
 		 _____                   _                        _     

--- a/freeciv-web/src/main/webapp/javascript/webgl/mapview.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/mapview.js
@@ -105,7 +105,7 @@ function webgl_start_renderer()
     anaglyph_effect.setSize( new_mapview_width, new_mapview_height );
   }
 
-  if (location.host != fcw_host && Detector.webgl) {
+  if (fcwDebug && Detector.webgl) {
     stats = new Stats();
     container.appendChild( stats.dom );
     console.log("MAX_FRAGMENT_UNIFORM_VECTORS:" + maprenderer.context.getParameter(maprenderer.context.MAX_FRAGMENT_UNIFORM_VECTORS));

--- a/freeciv-web/src/main/webapp/javascript/webgl/renderer_main.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/renderer_main.js
@@ -30,6 +30,11 @@ var anaglyph_3d_enabled = false;
 ****************************************************************************/
 function init_webgl_renderer()
 {
+  if (!Detector.webgl) {
+    swal("3D WebGL not supported by your browser or you don't have a 3D graphics card. Please go back and try the 2D version instead. ");
+    return;
+  }
+
   // load Three.js dynamically.
   $.ajax({
       async: false,
@@ -42,11 +47,6 @@ function init_webgl_renderer()
     url: "/javascript/webgl/libs/webgl-client" + fcwMinified + ".js",
     dataType: "script"
   });
-
-  if (!Detector.webgl) {
-    swal("3D WebGL not supported by your browser or you don't have a 3D graphics card. Please go back and try the 2D version instead. ");
-    return;
-  }
 
   /* Loads the two tileset definition files */
   $.ajax({

--- a/freeciv-web/src/main/webapp/javascript/webgl/renderer_main.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/renderer_main.js
@@ -37,10 +37,9 @@ function init_webgl_renderer()
       dataType: "script"
   });
 
-
   $.ajax({
     async: false,
-    url: (location.host == fcw_host) ? "/javascript/webgl/libs/webgl-client.min.js" : "/javascript/webgl/libs/webgl-client.js",
+    url: "/javascript/webgl/libs/webgl-client" + fcwMinified + ".js",
     dataType: "script"
   });
 

--- a/freeciv-web/src/main/webapp/webclient/index.jsp
+++ b/freeciv-web/src/main/webapp/webclient/index.jsp
@@ -6,19 +6,20 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
 String googleSigninClientKey = null;
-String fcwHost = null;
 String trackJsToken = null;
+boolean fcwDebug = false;
+String fcwMinified = "";
 try {
   Properties prop = new Properties();
   prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
   googleSigninClientKey = stripToEmpty(prop.getProperty("google-signin-client-key"));
   trackJsToken = stripToNull(prop.getProperty("trackjs-token"));
-  fcwHost = prop.getProperty("fcw_host");
+
+  String debugParam = request.getParameter("debug");
+  fcwDebug = (debugParam != null && (debugParam.isEmpty() || parseBoolean(debugParam)));
+  fcwMinified = fcwDebug ? "" : ".min";
 } catch (IOException e) {
   e.printStackTrace();
-}
-if (fcwHost == null || fcwHost.isEmpty()) {
-  fcwHost = request.getServerName();
 }
 %>
 <!DOCTYPE html>
@@ -26,7 +27,7 @@ if (fcwHost == null || fcwHost.isEmpty()) {
 <head>
 <title>Freeciv-web</title>
 <link rel="stylesheet" href="/css/font-awesome.min.css">
-<link rel="stylesheet" type="text/css" href="/css/webclient.min.css?ts=${initParam.buildTimeStamp}" />
+<link rel="stylesheet" type="text/css" href="/css/webclient<%= fcwMinified %>.css?ts=${initParam.buildTimeStamp}" />
 <meta name="description" content="Freeciv-Web is a Free and Open Source empire-building strategy game inspired by the history of human civilization.">
 <% if (trackJsToken != null) { %>
 <script type="text/javascript">window._trackJs = { token: '<%= trackJsToken %>' };</script>
@@ -34,17 +35,14 @@ if (fcwHost == null || fcwHost.isEmpty()) {
 <% } %>
 <script type="text/javascript">
 var ts="${initParam.buildTimeStamp}";
-var fcw_host="<%= fcwHost %>";
+var fcwDebug=<%= fcwDebug %>;
+var fcwMinified="<%= fcwMinified %>";
 </script>
 <script type="text/javascript" src="/javascript/libs/jquery.min.js?ts=${initParam.buildTimeStamp}"></script>
 
 <script src="https://apis.google.com/js/platform.js"></script>
 
-<% if (request.getServerName().equals(fcwHost)) { %>
-  <script type="text/javascript" src="/javascript/webclient.min.js?ts=${initParam.buildTimeStamp}"></script>
-<% } else { %>
-  <script type="text/javascript" src="/javascript/webclient.js?ts=${initParam.buildTimeStamp}"></script>
-<% } %>
+<script type="text/javascript" src="/javascript/webclient<%= fcwMinified %>.js?ts=${initParam.buildTimeStamp}"></script>
 
 <script type="text/javascript" src="/music/audio.min.js"></script>
 

--- a/freeciv-web/src/main/webapp/webclient/index.jsp
+++ b/freeciv-web/src/main/webapp/webclient/index.jsp
@@ -1,19 +1,21 @@
 <%@ page import="java.util.Properties" %>
 <%@ page import="java.io.IOException" %>
+<%@ page import="static org.apache.commons.lang3.StringUtils.stripToNull" %>
+<%@ page import="static org.apache.commons.lang3.StringUtils.stripToEmpty" %>
+<%@ page import="static java.lang.Boolean.parseBoolean" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
 String googleSigninClientKey = null;
 String fcwHost = null;
+String trackJsToken = null;
 try {
   Properties prop = new Properties();
   prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
-  googleSigninClientKey = prop.getProperty("google-signin-client-key");
+  googleSigninClientKey = stripToEmpty(prop.getProperty("google-signin-client-key"));
+  trackJsToken = stripToNull(prop.getProperty("trackjs-token"));
   fcwHost = prop.getProperty("fcw_host");
 } catch (IOException e) {
   e.printStackTrace();
-}
-if (googleSigninClientKey == null) {
-  googleSigninClientKey = "";
 }
 if (fcwHost == null || fcwHost.isEmpty()) {
   fcwHost = request.getServerName();
@@ -26,8 +28,8 @@ if (fcwHost == null || fcwHost.isEmpty()) {
 <link rel="stylesheet" href="/css/font-awesome.min.css">
 <link rel="stylesheet" type="text/css" href="/css/webclient.min.css?ts=${initParam.buildTimeStamp}" />
 <meta name="description" content="Freeciv-Web is a Free and Open Source empire-building strategy game inspired by the history of human civilization.">
-<% if (request.getServerName().equals(fcwHost)) { %>
-<script type="text/javascript">window._trackJs = { token: 'ee5dba6fe2e048f79b422157b450947b' };</script>
+<% if (trackJsToken != null) { %>
+<script type="text/javascript">window._trackJs = { token: '<%= trackJsToken %>' };</script>
 <script type="text/javascript" src="https://cdn.trackjs.com/releases/current/tracker.js"></script>
 <% } %>
 <script type="text/javascript">


### PR DESCRIPTION
Fixes #175 

* trackjs scripts are only loaded if `trackjs-token` is specified
* trackjs-token is empty (disabled) by default, and not tied to
  a hostname. Uncomment and specify in config if you want tracking
* Also adds abilty to show un-minified `webclient.js` and `webclient.css`
  by adding `?debug` to url, even on hosted sites (still uses fcw_host
  to send minified)