### PR TITLE
Load Google Analytics only when configured

### DIFF
--- a/freeciv-web/src/main/webapp/WEB-INF/config.properties.dist
+++ b/freeciv-web/src/main/webapp/WEB-INF/config.properties.dist
@@ -3,6 +3,7 @@ savegame_dir=/var/lib/tomcat8/webapps/data/savegames/
 email_username=username
 email_password=password
 google-signin-client-key=122428231951-2vrvrtd9sc2v9nktemclkvc2t187jkr6.apps.googleusercontent.com
+#ga-tracking-id=UA-40584174-1
 #trackjs-token=ee5dba6fe2e048f79b422157b450947b
 # Used in some messages, so put the production server even when testing.
 fcw_host=example.com

--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/head.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/head.jsp
@@ -2,10 +2,12 @@
 <%@ page import="java.util.Properties" %>
 <%@ page import="java.io.IOException" %>
 <%
+    String gaTrackingId = null;
     String trackJsToken = null;
     try {
         Properties prop = new Properties();
         prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
+        gaTrackingId = stripToNull(prop.getProperty("ga-tracking-id"));
         trackJsToken = stripToNull(prop.getProperty("trackjs-token"));
     } catch (IOException e) {
         e.printStackTrace();
@@ -31,15 +33,17 @@
 
 <link rel="manifest" href="/static/manifest.json">
 
+<% if (gaTrackingId != null) { %>
 <script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-	ga('create', 'UA-40584174-1', 'auto');
+	ga('create', '<%= gaTrackingId =%>>', 'auto');
 	ga('send', 'pageview');  
 </script>
+<% } %>
 <% if (trackJsToken != null) { %>
 <script type="text/javascript">window._trackJs = { token: '<%= trackJsToken %>' };</script>
 <script type="text/javascript" src="https://cdn.trackjs.com/releases/current/tracker.js"></script>

--- a/freeciv-web/src/main/webapp/webclient/index.jsp
+++ b/freeciv-web/src/main/webapp/webclient/index.jsp
@@ -5,6 +5,7 @@
 <%@ page import="static java.lang.Boolean.parseBoolean" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
+String gaTrackingId = null;
 String googleSigninClientKey = null;
 String trackJsToken = null;
 boolean fcwDebug = false;
@@ -12,6 +13,7 @@ String fcwMinified = "";
 try {
   Properties prop = new Properties();
   prop.load(getServletContext().getResourceAsStream("/WEB-INF/config.properties"));
+  gaTrackingId = stripToNull(prop.getProperty("ga-tracking-id"));
   googleSigninClientKey = stripToEmpty(prop.getProperty("google-signin-client-key"));
   trackJsToken = stripToNull(prop.getProperty("trackjs-token"));
 
@@ -68,16 +70,17 @@ var fcwMinified="<%= fcwMinified %>";
 <body>
     <jsp:include page="pregame.jsp" flush="false"/>
     <jsp:include page="game.jsp" flush="false"/>
-    
+
+<% if (gaTrackingId != null) { %>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-40584174-1', 'auto');
+  ga('create', '<%= gaTrackingId %>', 'auto');
   ga('send', 'pageview');
-</script> 
+</script>
+<% } %>
 </body>
 
 <script id="terrain_fragment_shh" type="x-shader/x-fragment">


### PR DESCRIPTION
Adds a `ga-tracking-id` property to `WEB-INF/config.properties` that
will enable google analytics if present, or simply not include the
javascript otherwise.

Not that this will require servers that wish to use it to _uncomment_ the `ga-tracking-id` in the default `freeciv-web/src/main/webapp/WEB-INF/config.properties` (when copied from `config.properties.dist`) or add it to their existing config (@andreasrosdal ).

fixes #197 