### PR TITLE
Fix GLTFLoader

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/webgl/libs/GLTFLoader.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/libs/GLTFLoader.js
@@ -2113,6 +2113,7 @@ THREE.GLTFLoader = ( function () {
 	GLTFParser.prototype.loadMaterial = function ( materialIndex ) {
 
 		var parser = this;
+		var json = this.json;
 		var extensions = this.extensions;
 		var materialDef = json.materials[ materialIndex ];
 
@@ -2486,6 +2487,7 @@ THREE.GLTFLoader = ( function () {
 	GLTFParser.prototype.loadMesh = function ( meshIndex ) {
 
 		var scope = this;
+		var json = this.json;
 		var extensions = this.extensions;
 
 		var meshDef = json.meshes[ meshIndex ];
@@ -2929,6 +2931,7 @@ THREE.GLTFLoader = ( function () {
 	 */
 	GLTFParser.prototype.loadNode = function ( nodeIndex ) {
 
+		var json = this.json;
 		var extensions = this.extensions;
 
 		var meshReferences = json.meshReferences;
@@ -3124,7 +3127,7 @@ THREE.GLTFLoader = ( function () {
 
 			var json = this.json;
 			var extensions = this.extensions;
-			var sceneDef = this.json.scenes[ sceneIndex ];
+			var sceneDef = json.scenes[ sceneIndex ];
 
 			return this.getMultiDependencies( [
 


### PR DESCRIPTION
Commits 2fd938e and 734ec52 "conflicted" though did not have overlapping
code so did not cause a merge conflict. One eliminated redundant local
variable creation, the other removed references to `this` so as to use
the local variables.