### PR TITLE
Delete sourcemap files during maven initialization

### DIFF
--- a/freeciv-web/build-js.sh
+++ b/freeciv-web/build-js.sh
@@ -3,10 +3,6 @@
 
 FCW_DEST=/var/lib/tomcat8/webapps/freeciv-web
 
-# workaround for https://github.com/samaxes/minify-maven-plugin/issues/142
-rm -rf target/freeciv-web/javascript/webclient.min.js.map
-rm -rf target/freeciv-web/javascript/webgl/libs/webgl-client.min.js.map
-
 mvn compile && \
 echo "Copying target/javascript/webclient.* to ${FCW_DEST}/javascript" && \
   cp target/freeciv-web/javascript/webclient.* "${FCW_DEST}"/javascript/ && \

--- a/freeciv-web/pom.xml
+++ b/freeciv-web/pom.xml
@@ -246,6 +246,21 @@ Rerun the sync-js-hand.js script.
 					<version>1.8</version>
 					<executions>
 						<execution>
+							<!-- workaround for https://github.com/samaxes/minify-maven-plugin/issues/142 -->
+							<id>source-mapping-fix</id>
+							<phase>initialize</phase>
+							<goals>
+								<goal>run</goal>
+							</goals>
+							<configuration>
+								<target>
+									<delete quiet="true">
+										<fileset dir="${project.build.directory}/freeciv-web/javascript" includes="**/*.map"/>
+									</delete>
+								</target>
+							</configuration>
+						</execution>
+						<execution>
 							<id>create-generated-javascript-dir</id>
 							<phase>generate-sources</phase>
 							<goals>
@@ -259,6 +274,7 @@ Rerun the sync-js-hand.js script.
 						</execution>
 					</executions>
 				</plugin>
+
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>


### PR DESCRIPTION
Due to a defect in minify-maven-plugin source maps are not regenerated
if they already exist. This pr moves the workaround from the build
script to the "official" build tool, ensuring it happens for all builds
that generate javascript

closes #205 