### PR TITLE
Free longturn games from longturn_server_port list

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -41,8 +41,8 @@ Freeciv has AI related
 
 # Freeciv-web LongTurn
 
-Activation of LongTurn support is configured as a list of port numbers in this file:
-publite2/settings.ini 
+Activation of LongTurn games is handled by adding the server commands files:
+publite2/pubscript_longturn_*.serv
 
 # Rules
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -41,10 +41,8 @@ Freeciv has AI related
 
 # Freeciv-web LongTurn
 
-Activation of LongTurn support is configured as a list of port numbers in these files:
+Activation of LongTurn support is configured as a list of port numbers in this file:
 publite2/settings.ini 
-freeciv/patches/longturn.patch
-freeciv-web\src\main\webapp\javascript\civcliet.js  is_longturn()
 
 # Rules
 

--- a/README-One-Turn-Per-Day.md
+++ b/README-One-Turn-Per-Day.md
@@ -5,10 +5,6 @@ LongTurn games require some manual configuration to work.
 File: publite2\settings.ini
 Config: Add LongTurn game server ports to the 'longturn_server_ports' variable.
 
-File: freeciv-web\src\main\webapp\javascript\civclient.js 
-Add LongTurn game server ports to the 'longturn_server_port_list' variable.
-(Changing this requires recompiling Freeciv-web using freeciv-web/build-js.sh)
-
 LongTurn game specific server settings:
 publite2\pubscript_longturn_6003.serv
 publite2\pubscript_longturn_6004.serv

--- a/README-One-Turn-Per-Day.md
+++ b/README-One-Turn-Per-Day.md
@@ -1,14 +1,10 @@
 Configuration of One Turn per Day (LongTurn) games in Freeciv-web
 
-LongTurn games require some manual configuration to work. 
-
-File: publite2\settings.ini
-Config: Add LongTurn game server ports to the 'longturn_server_ports' variable.
-
-LongTurn game specific server settings:
-publite2\pubscript_longturn_6003.serv
-publite2\pubscript_longturn_6004.serv
+Just drop a LongTurn game specific server settings file in the publite2 directory:
+publite2/pubscript_longturn_6003.serv
+publite2/pubscript_longturn_Europe.serv
+publite2/pubscript_longturn_Whatever.serv
 
 
-freeciv\patches\longturn.patch is a patch which adds LongTurn support
+freeciv/patches/longturn.patch is a patch which adds LongTurn support
 to the Freeciv C server, and it is automatically applied to the source code.

--- a/freeciv-web/src/main/java/org/freeciv/model/Game.java
+++ b/freeciv-web/src/main/java/org/freeciv/model/Game.java
@@ -10,6 +10,8 @@ public class Game {
 
 	private String patches;
 
+	private String type;
+
 	private String state;
 
 	private String message;
@@ -54,6 +56,10 @@ public class Game {
 
 	public int getPort() {
 		return port;
+	}
+
+	public String getType() {
+		return type;
 	}
 
 	public String getState() {
@@ -109,6 +115,11 @@ public class Game {
 
 	public Game setPort(int port) {
 		this.port = port;
+		return this;
+	}
+
+	public Game setType(String type) {
+		this.type = type;
 		return this;
 	}
 

--- a/freeciv-web/src/main/java/org/freeciv/services/Games.java
+++ b/freeciv-web/src/main/java/org/freeciv/services/Games.java
@@ -67,7 +67,7 @@ public class Games {
 			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
 			connection = ds.getConnection();
 
-			query = "SELECT host, port, version, patches, state, message, " //
+			query = "SELECT host, port, type, version, patches, state, message, " //
 					+ "UNIX_TIMESTAMP()-UNIX_TIMESTAMP(stamp) AS duration, " //
 					+ "	(SELECT COUNT(*) " //
 					+ "	  FROM players " //
@@ -90,6 +90,7 @@ public class Games {
 				Game game = new Game() //
 						.setHost(rs.getString("host")) //
 						.setPort(rs.getInt("port")) //
+						.setType(rs.getString("type")) //
 						.setVersion(rs.getString("version")) //
 						.setPatches(rs.getString("patches")) //
 						.setState(rs.getString("state")) //
@@ -157,7 +158,7 @@ public class Games {
 			Context env = (Context) (new InitialContext().lookup("java:comp/env"));
 			DataSource ds = (DataSource) env.lookup("jdbc/freeciv_mysql");
 			connection = ds.getConnection();
-			query = "SELECT host, port, version, patches, state, message, " //
+			query = "SELECT host, port, type, version, patches, state, message, " //
 					+ "	unix_timestamp()-unix_timestamp(stamp) AS duration, " //
 					+ "	IFNULL(" //
 					+ "		(SELECT user FROM players p WHERE p.hostport = CONCAT(s.host ,':',s.port) AND p.type = 'Human' LIMIT 1 )," //
@@ -189,6 +190,7 @@ public class Games {
 				Game game = new Game() //
 						.setHost(rs.getString("host")) //
 						.setPort(rs.getInt("port")) //
+						.setType(rs.getString("type")) //
 						.setVersion(rs.getString("version")) //
 						.setPatches(rs.getString("patches")) //
 						.setState(rs.getString("state")) //
@@ -228,7 +230,7 @@ public class Games {
 
 			String query = "" //
 					+ "  ( " //
-					+ "    SELECT host, port, version, patches, state, message, " //
+					+ "    SELECT host, port, type, version, patches, state, message, " //
 					+ "    UNIX_TIMESTAMP() - UNIX_TIMESTAMP(stamp) AS duration, " //
 					+ "    (SELECT value " //
 					+ "       FROM variables " //
@@ -240,7 +242,7 @@ public class Games {
 					+ "  ) " //
 					+ "UNION " //
 					+ "  ( " //
-					+ "    SELECT host, port, version, patches, state, message, " //
+					+ "    SELECT host, port, type, version, patches, state, message, " //
 					+ "    UNIX_TIMESTAMP() - UNIX_TIMESTAMP(stamp) AS duration, " //
 					+ "    (SELECT value " //
 					+ "       FROM variables " //
@@ -256,7 +258,7 @@ public class Games {
 					+ "  ) " //
 					+ "UNION " //
 					+ "  ( " //
-					+ "    SELECT host, port, version, patches, state, message, " //
+					+ "    SELECT host, port, type, version, patches, state, message, " //
 					+ "    UNIX_TIMESTAMP()-UNIX_TIMESTAMP(stamp), " //
 					+ "    (SELECT value " //
 					+ "       FROM variables " //
@@ -275,6 +277,7 @@ public class Games {
 				multiplayerGames.add(new Game() //
 						.setHost(rs.getString("host")) //
 						.setPort(rs.getInt("port")) //
+						.setType(rs.getString("type")) //
 						.setVersion(rs.getString("version")) //
 						.setPatches(rs.getString("patches")) //
 						.setState(rs.getString("state")) //

--- a/freeciv-web/src/main/java/org/freeciv/servlet/GameDetails.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/GameDetails.java
@@ -136,6 +136,7 @@ public class GameDetails extends HttpServlet {
 				request.setAttribute("serverid", rs.getString("serverid"));
 				request.setAttribute("port", port);
 				request.setAttribute("host", sHost);
+				request.setAttribute("type", rs.getString("type"));
 			} else {
 				RequestDispatcher rd = request.getRequestDispatcher("game-information.jsp");
 				rd.forward(request, response);

--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/header.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/fragments/header.jsp
@@ -17,7 +17,7 @@
 		<!-- Collect the nav links, forms, and other panel-freeciv for toggling -->
 		<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 		<ul class="nav navbar-nav">
-			<li><a href="/webclient/?action=new">New Game</a></li>
+			<li><a href="/webclient/?action=new&amp;type=singleplayer">New Game</a></li>
 			<li class="dropdown">
 				<a href="/game/list?v=singleplayer" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
 					<span onclick="window.location='/game/list?v=singleplayer'">Online Games</span> <span class="caret"></span> <span class="badge ongoing-games-number" id="ongoing-games" title="Ongoing games"></span>

--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/game/details.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/game/details.jsp
@@ -121,13 +121,13 @@
 						<c:choose>
 							<c:when test="${state == 'Pregame'}">
 								<div>
-									<a class="label label-success" href="/webclient/?action=multi&civserverport=${port}&amp;civserverhost=${host}">
+									<a class="label label-success" href="/webclient/?action=multi&civserverport=${port}&amp;civserverhost=${host}&amp;type=${type}">
 										Join</a> You can join this game now.
 								</div>
 							</c:when>
 							<c:otherwise>
 								<div>
-									<a class="label label-primary" href="/webclient/?action=multi&civserverport=${port}&amp;civserverhost=${host}">
+									<a class="label label-primary" href="/webclient/?action=multi&civserverport=${port}&amp;civserverhost=${host}&amp;type=${type}">
 										Join/Observe</a> You can observe this game now.
 								</div>
 							</c:otherwise>

--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/game/list.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/game/list.jsp
@@ -180,9 +180,9 @@
 									<td class="hidden-xs">${game.players}</td>
 									<td class="hidden-xs">${game.turn}</td>
 									<td><a class="label label-success label-lg"
-										href="/webclient?action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}" title="Observe">
+										href="/webclient?action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;type=${game.type}" title="Observe">
 											2D</a> <a class="label label-success label-lg"
-										href="/webclient?renderer=webgl&amp;action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}" title="Observe">
+										href="/webclient?renderer=webgl&amp;action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;type=${game.type}" title="Observe">
 											3D</a> <a class="label label-primary label-lg"
 										href="/game/details?host=${game.host}&amp;port=${game.port}">
 											Info</a>
@@ -192,7 +192,7 @@
 						</table>
 					</c:if>
 					<c:if test="${fn:length(singlePlayerGameList) == 0}">
-							<a class="label label-primary" href="/webclient/?action=new">Start</a> a new single player game! 
+							<a class="label label-primary" href="/webclient/?action=new&amp;type=singleplayer">Start</a> a new single player game!
 					</c:if>
 				</div>
 	
@@ -228,19 +228,21 @@
 									<td><c:choose>
 											<c:when test="${game.state != 'Running'}">
 												<a class="label label-success label-lg"
-													href="/webclient?action=multi&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true">
+													href="/webclient?action=multi&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true&amp;type=${game.type}">
 													Play</a>
 											</c:when>
 											<c:otherwise>
                                                 <a class="label label-success label-lg"
-													href="/webclient?action=multi&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true">
+													href="/webclient?action=multi&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true&amp;type=${game.type}">
 													Play 2D</a>
+											<c:if test="${game.type} ne 'longturn'}">
 												<a class="label label-success label-lg"
-													href="/webclient?action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true">
+													href="/webclient?action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true&amp;type=${game.type}">
 													Observe 2D</a>
 												<a class="label label-success label-lg"
-													href="/webclient?renderer=webgl&amp;action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true">
+													href="/webclient?renderer=webgl&amp;action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true&amp;type=${game.type}">
 													3D</a>
+											</c:if>
 											</c:otherwise>
 										</c:choose>
 										<a class="label label-primary label-lg"	href="/game/details?host=${game.host}&amp;port=${game.port}">
@@ -267,7 +269,7 @@
 							</p>
 							<p>
 								To start a new Play-By-Email game, 
-								<u></u></ul><a href="/webclient/?action=pbem">log in here</a></u>. To play your turn
+								<a href="/webclient/?action=pbem&amp;type=pbem">log in here</a></u>. To play your turn
 								in a running Play-By-Email game, click on the link in the last
 								e-mail you got from Freeciv-web. Games are expired after 7 days if
 								you don't play your turn.

--- a/freeciv-web/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/freeciv-web/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -124,16 +124,6 @@
 				<div class="row top-buffer-3">
 					<p class="lead">
 						<fmt:message key="index-lead"/>
-
-                         <%--<div class="row top-buffer-3">
-                         <h1>Join Freeciv-web: One Turn per Day game XII</h1>
-                         <b>Game XII XI has started and you can join it now!</b><br>
-                         <b>Each player will play one turn every day. <br><br>
-                         This will be one of the greatest ever multiplayer game of Freeciv with 300 players on 30000 map tiles!<br>
-                         </b>
-                         <h2><a href="/webclient?action=multi&civserverport=6006&civserverhost=play&multi=true">Join the LongTurn Web XII here!</a></h2>
-			            </div>--%>
-
 					</p>
 				</div>
 			</div>
@@ -152,14 +142,14 @@
 								Play against the Freeciv AI with 2D HTML5 graphics
 							</div>
 						</c:if>
-						<a id="single-button" href="/webclient/?action=new" class="btn"><i class="fa fa-flag"></i> <fmt:message key="index-game-launcher-2d"/></a>
+						<a id="single-button" href="/webclient/?action=new&type=singleplayer" class="btn"><i class="fa fa-flag"></i> <fmt:message key="index-game-launcher-2d"/></a>
 
 						<c:if test="${default_lang}">
 							<div class="features">
 								Play against the Freeciv AI with 3D WebGL<br>graphics using the Three.js 3D engine
 							</div>
 						</c:if>
-						<a href="/webclient/?action=new&renderer=webgl" class="btn" id="webgl_button"><i class="fa fa-cube"></i> <fmt:message key="index-game-launcher-3d"/></a>
+						<a href="/webclient/?action=new&renderer=webgl&type=singleplayer" class="btn" id="webgl_button"><i class="fa fa-cube"></i> <fmt:message key="index-game-launcher-3d"/></a>
 
 
 						<c:if test="${default_lang}">
@@ -167,7 +157,7 @@
 								Start on a scenario map, such as <br> World map, America, Italy or Japan.
 							</div>
 						</c:if>
-						<a href="/webclient/?action=load&amp;scenario=true" class="btn"><i class="fa fa-map-o"></i> <fmt:message key="index-game-launcher-scenario"/></a>
+						<a href="/webclient/?action=load&amp;scenario=true&type=singleplayer" class="btn"><i class="fa fa-map-o"></i> <fmt:message key="index-game-launcher-scenario"/></a>
 						<c:if test="${default_lang}">
 							<div class="features">
 								Choose your map from a real earth map.
@@ -192,23 +182,19 @@
 								Start a play-by-email game where you get an e-mail <br> when it is your turn to play.
 							</div>
 						</c:if>
-						<a href="/webclient/?action=pbem" class="btn"><i class="fa fa-envelope"></i> <fmt:message key="index-game-launcher-play-by-email"/></a>
+						<a href="/webclient/?action=pbem&type=pbem" class="btn"><i class="fa fa-envelope"></i> <fmt:message key="index-game-launcher-play-by-email"/></a>
 						<c:if test="${default_lang}">
 							<div class="features">
 								Play multiple human players <br> on the same computer
 							</div>
 						</c:if>
-						<a href="/webclient/?action=hotseat" class="btn"><i class="fa fa-user-plus"></i> <fmt:message key="index-game-launcher-hotseat" /></a>
+						<a href="/webclient/?action=hotseat&type=singleplayer" class="btn"><i class="fa fa-user-plus"></i> <fmt:message key="index-game-launcher-hotseat" /></a>
 
 						<c:if test="${default_lang}">
 							<div class="features">
 								Play a <b>Freeciv-web One Turn per Day</b>, where up to 300 human <br>players play one turn every day:
 							</div>
 						</c:if>
-						<a href="/webclient?action=multi&civserverport=6004&civserverhost=play&multi=true" class="btn" style="font-size: 15px; padding: 4px;">Game X - One Turn per Day</a>
-						<a href="/webclient?action=multi&civserverport=6005&civserverhost=play&multi=true" class="btn" style="font-size: 15px; padding: 4px;">Game XI - One Turn per Day</a>
-						<a href="/webclient?action=multi&civserverport=6006&civserverhost=play&multi=true" class="btn" style="font-size: 15px; padding: 4px;">Game XII - One Turn per Day</a>
-						<a href="/webclient?action=multi&civserverport=6007&civserverhost=play&multi=true" class="btn" style="font-size: 15px; padding: 4px;">Game XIII - One Turn per Day</a>
 
 					</div>
 				</div>
@@ -291,12 +277,12 @@
 										<td>
 											<c:choose>
 												<c:when test="${game.state == 'Running' or game.state == 'Pregame'}">
-													<a  class="label label-success" href="/webclient/?action=multi&civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true">
+													<a  class="label label-success" href="/webclient/?action=multi&civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true&amp;type=${game.type}">
 														Play
 													</a>
 												</c:when>
 												<c:otherwise>
-													<a class="label label-success" href="/webclient/?action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true">
+													<a class="label label-success" href="/webclient/?action=observe&amp;civserverport=${game.port}&amp;civserverhost=${game.host}&amp;multi=true&amp;type=${game.type}">
 														Observe
 													</a>
 												</c:otherwise>

--- a/freeciv-web/src/main/webapp/freeciv-earth/earth.js
+++ b/freeciv-web/src/main/webapp/freeciv-earth/earth.js
@@ -79,9 +79,9 @@ $.ajax({
   data: postData
 }).done(function(responsedata) {
     if (!renderer_3d) {
-      window.location.href="/webclient/?action=earthload&savegame=" + responsedata;
+      window.location.href="/webclient/?action=earthload&type=singleplayer&savegame=" + responsedata;
     } else {
-      window.location.href="/webclient/?action=earthload&savegame=" + responsedata + "&renderer=webgl";
+      window.location.href="/webclient/?action=earthload&type=singleplayer&savegame=" + responsedata + "&renderer=webgl";
     }
   })
   .fail(function() {

--- a/freeciv-web/src/main/webapp/javascript/civclient.js
+++ b/freeciv-web/src/main/webapp/javascript/civclient.js
@@ -31,8 +31,8 @@ var username = null;
 
 var fc_seedrandom = null;
 
-// List of ports which are reserved for LongTurn games.
-var longturn_server_port_list = [6003,6004,6005,6006,6007];
+// singleplayer, multiplayer, longturn, pbem
+var game_type = "";
 
 var music_list = [ "battle-epic",
                    "andrewbeck-ancient",
@@ -72,7 +72,30 @@ function civclient_init()
   $.blockUI.defaults['css']['color'] = "#fff";
   $.blockUI.defaults['theme'] = true;
 
-  if ($.getUrlVar('action') == "observe") {
+  var action = $.getUrlVar('action');
+  game_type = $.getUrlVar('type');
+  if (game_type == null) {
+    if (action == null || action == 'multi') {
+      swal({
+             title: "Unknown game type",
+             text: "For some reason the client can't determine what kind of game this is. Please <a href='https://github.com/freeciv/freeciv-web/issues'>open an issue</a> detailing how you got here",
+             html: true,
+             type: "error"
+           },
+           // Requires a parameter to also be called on cancel
+           function (unused) {
+             window.location.href ='/';
+           }
+      );
+      return;
+    } else if (action == 'pbem') {
+      game_type = 'pbem';
+    } else {
+      game_type = 'singleplayer';
+    }
+  }
+
+  if (action == "observe") {
     observing = true;
     $("#civ_tab").remove();
     $("#cities_tab").remove();
@@ -636,10 +659,5 @@ function switch_renderer()
 **************************************************************************/
 function is_longturn()
 {
-  for (var i = 0; i < longturn_server_port_list.length; i++) {
-    if (longturn_server_port_list[i] == civserverport || $.getUrlVar('civserverport') == longturn_server_port_list[i]) {
-      return true;
-    }
-  }
-  return false;
+  return game_type == "longturn";
 }

--- a/freeciv-web/src/main/webapp/javascript/savegame.js
+++ b/freeciv-web/src/main/webapp/javascript/savegame.js
@@ -58,7 +58,7 @@ function save_game()
   if (!logged_in_with_password) {
     dhtml += "<br><br>Warning: You have not logged in using a user account with password. Please "
     + "create a new user account with password next time you want save, so you are sure"
-    + " you can load the savegame with a username and password. <a href='/webclient/?action=new'>Click here</a> "
+    + " you can load the savegame with a username and password. <a href='/webclient/?action=new&amp;type=singleplayer'>Click here</a> "
     + "to start a new game, then click on the \"New User Account\" button to create a new account.<br>"
   }
 

--- a/freeciv-web/src/main/webapp/pbem/index.jsp
+++ b/freeciv-web/src/main/webapp/pbem/index.jsp
@@ -24,7 +24,7 @@ var getUrlParameter = function getUrlParameter(sParam) {
 
 var u = getUrlParameter('u');
 if (u != null) {
-  window.location="/webclient/?action=pbem&invited_by=" + u;
+  window.location="/webclient/?action=pbem&type=pbem&invited_by=" + u;
 } else {
   alert("missing user url paramter.");
 }

--- a/pbem/email_template_invitation.html
+++ b/pbem/email_template_invitation.html
@@ -12,7 +12,7 @@ play-by-email game that you can play in your browser for free.
 
 
 <br><br>
-<a href="https://{host}/webclient/?action=pbem&invited_by={sender}" style="color: white; background-color: #3c98ff; padding: 10px; font-size: 160%;">Please click here to play your first turn!</a>
+<a href="https://{host}/webclient/?action=pbem&invited_by={sender}&type=pbem" style="color: white; background-color: #3c98ff; padding: 10px; font-size: 160%;">Please click here to play your first turn!</a>
 
 <br><br>
 

--- a/pbem/pbem.py
+++ b/pbem/pbem.py
@@ -120,7 +120,7 @@ def handle_savegame(root, file):
   active_player = players[phase];
   print("active_player=" + active_player);    
   active_email = find_email_address(active_player);
-  game_url = "https://" + host + "/webclient/?action=pbem&savegame=" + new_filename.replace(".xz", "");
+  game_url = "https://" + host + "/webclient/?action=pbem&type=pbem&savegame=" + new_filename.replace(".xz", "");
   if (active_email != None):
     status.games[game_id] = {'turn' : turn, 'phase': phase, 'players' : players, 'time_str' : time.ctime(), 
                              'time_int' : int(time.time()), 'state' : state, 'url' : game_url, 

--- a/publite2/settings.ini.dist
+++ b/publite2/settings.ini.dist
@@ -2,12 +2,6 @@
 #Freeciv savegames are stored in this directory
 save_directory = /var/lib/tomcat8/webapps/data/savegames/
 
-# Activation of LongTurn games.
-start_longturn = false
-
-#list of server ports which are reserved for LongTurn.
-longturn_server_ports=6003,6004,6005,6006,6007
-
 [Resource usage]
 server_capacity_single = 2
 server_capacity_multi = 1

--- a/tests/freeciv-web-autogame.js
+++ b/tests/freeciv-web-autogame.js
@@ -10,7 +10,7 @@ casper.options.waitTimeout = 60 * 60 * 1000;
 casper.options.viewportSize = {width: 1024, height: 768};
 
 casper.test.begin('Test starting new Freeciv-web autogame', 3, function suite(test) {
-    casper.start("http://localhost/webclient/?action=new");
+    casper.start("http://localhost/webclient/?action=new&type=singleplayer");
 
     casper.waitForSelector('#username_req', function() {
         test.assertHttpStatus(200);

--- a/tests/freeciv-web-tests.js
+++ b/tests/freeciv-web-tests.js
@@ -77,7 +77,7 @@ casper.test.begin('Test of Freeciv-web frontpage', 3, function suite(test) {
 });
 
 casper.test.begin('Test starting new Freeciv-web game', 10, function suite(test) {
-    casper.start("http://localhost/webclient/?action=new", function() {
+    casper.start("http://localhost/webclient/?action=new&type=singleplayer", function() {
         test.assertHttpStatus(200);
         test.assertTitleMatch(/Freeciv-web/, 'Freeciv-web title is present');
     });
@@ -181,7 +181,7 @@ casper.test.begin('Test starting new Freeciv-web game', 10, function suite(test)
 
 casper.test.begin('Test pregame settings dialog ruleset switcher',
                   3, function suite(test) {
-  casper.start("http://localhost/webclient/?action=new");
+  casper.start("http://localhost/webclient/?action=new&type=singleplayer");
 
   casper.waitForSelector('#username_req', function() {
     this.echo("Filling in username in new game dialog.");


### PR DESCRIPTION
4e4ec24255fbfc9a8ebbf0d991ed12191a9fa080 split multiplayer game type to make a distinction with longturn games, and removed the hardcoded list of ports from the freeciv server patch. That allowed adding and removing longturn games without having to recompile the freeciv server. But the list was still used in the client code and in the launcher.

The list from the client is removed by using a parameter in the URL. It may be worth finding out where all those parameters are used and whether some may be removed or at least joined. There's for example `action=multi` for both common multiplayer games and longturn ones, and another parameter with name (not value) `multi`.

The list is also removed from the launcher. It now uses the commands files it finds, launching a new server for each, in whatever port is available. A side effect to consider is that a game may run in a different port if the server is restarted.

Related (to lt, but not to ports) in the TODO list:
- Make different games save to different directories (or at least different prefix)
- On server startup, check for the existence of savegames and load the last one (for restarts)
- Start the game, not just the server
- Distribute the games along the day, not just whenever a new commands file is found