### PR TITLE
Fix: use extras list to show resources

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
+++ b/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
@@ -1077,15 +1077,15 @@ function get_tile_label_text(ptile)
 ****************************************************************************/
 function get_tile_specials_sprite(ptile)
 {
-  if (ptile == null || ptile['resource'] == null) return null;
+  const extra_id = tile_resource(ptile);
 
-  var extra = extras[ptile['resource']];
-
-  if (extra == null) {
-    return null;
+  if (extra_id !== null) {
+    const extra = extras[extra_id];
+    if (extra != null) {
+      return  {"key" : extra['graphic_str']} ;
+    }
   }
-
-  return  {"key" : extra['graphic_str']} ;
+  return null;
 }
 
 /****************************************************************************

--- a/freeciv-web/src/main/webapp/javascript/map.js
+++ b/freeciv-web/src/main/webapp/javascript/map.js
@@ -117,7 +117,6 @@ function tile_init(tile)
   tile['known'] = null;  /* tile_known in C side */
   tile['seen'] = {};     /* tile_seen in C side */
   tile['specials'] = [];
-  tile['resource'] = null;
   tile['terrain'] = T_UNKNOWN;
   tile['units'] = [];
   tile['owner'] = null;

--- a/freeciv-web/src/main/webapp/javascript/tile.js
+++ b/freeciv-web/src/main/webapp/javascript/tile.js
@@ -54,14 +54,16 @@ function tile_has_extra(ptile, extra)
 
 function tile_resource(tile)
 {
-  return tile['resource'];
+  if (tile != null && tile.extras != null) {
+    const tile_extras = tile.extras.toBitSet();
+    for (var extra in tile_extras) {
+      if (is_extra_caused_by(extras[tile_extras[extra]], EC_RESOURCE)) {
+        return tile_extras[extra];
+      }
+    }
+  }
+  return null;
 }
-
-function tile_set_resource(tile, resource)
-{
-  tile['resource'] = resource;
-}
-
 
 function tile_owner(tile)
 {

--- a/freeciv-web/src/main/webapp/javascript/webgl/object_position_handler.js
+++ b/freeciv-web/src/main/webapp/javascript/webgl/object_position_handler.js
@@ -411,7 +411,8 @@ function update_tile_extras(ptile) {
   update_tile_extra_update_model(EXTRA_FORTRESS, "Fortress", ptile);
 
   // Render tile specials (extras). Fish and whales are 3D models, the rest are 2D sprites from the 2D version.
-  var extra_resource = extras[ptile['resource']];
+  const extra_id = tile_resource(ptile);
+  var extra_resource = (extra_id === null) ? null : extras[extra_id];
   if (extra_resource != null && scene != null && tile_extra_positions[extra_resource['id'] + "." + ptile['index']] == null) {
     if (extra_resource['name'] != "Fish" && extra_resource['name'] != "Whales"
         && (!tile_has_extra(ptile, EXTRA_RIVER)) /* rendering specials on rivers is not supported yet. */) {


### PR DESCRIPTION
The resource field only makes sense in the server, it is used to know
a tile has a resource even if terrain changes and it's not valid, in
case it changes back. It's not even rebuilt for the private map when
loading a game. Real valid resources are in the extras list.

Fixes #41 (resources not shown from a loaded savegame)
Fixes fish on swamp and other such resources in changed terrain