### PR TITLE
Create a docker volume plugin for referencing rulesets by git revision

### DIFF
--- a/codeoflaws/Dockerfile
+++ b/codeoflaws/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.11-alpine as builder
+COPY . /go/src/github.com/freeciv/freeciv-web/codeoflaws
+WORKDIR /go/src/github.com/freeciv/freeciv-web/codeoflaws/codeoflaws
+RUN set -ex \
+    && apk add --no-cache --virtual .build-deps \
+    gcc libc-dev git \
+    && go get github.com/rminnich/go9p \
+    github.com/docker/go-plugins-helpers/volume \
+    github.com/golang/glog github.com/google/uuid \
+    gopkg.in/src-d/go-git.v4
+RUN go install --ldflags '-extldflags "-static"' \
+    && apk del .build-deps
+CMD ["/go/bin/codeoflaws"]
+
+FROM alpine
+RUN apk add ca-certificates
+RUN mkdir -p /run/docker/plugins /mnt/volumes
+COPY --from=builder /go/bin/codeoflaws .
+CMD ["codeoflaws"]

--- a/codeoflaws/codeoflaws/main.go
+++ b/codeoflaws/codeoflaws/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/freeciv/freeciv-web/codeoflaws"
+	"github.com/golang/glog"
+	git "gopkg.in/src-d/go-git.v4"
+)
+
+const pluginSocketPath = "/run/docker/plugins/codeoflaws.sock"
+
+var (
+	p9SocketPath = flag.String("p9_socket", "/p9.sock", "Unix socket path for 9p server")
+	repoDir      = flag.String("git_repo", "/mnt/repo/freeciv.git", "Path of git repository to use")
+)
+
+func main() {
+	flag.Parse()
+
+	d := codeoflaws.NewVolumeDriver(*p9SocketPath)
+	h := volume.NewHandler(d)
+	go h.ServeUnix(pluginSocketPath, 0)
+
+	r, err := git.PlainOpen(*repoDir)
+	if err == git.ErrRepositoryNotExists {
+		glog.Infof("Cloning repo")
+		r, err = git.PlainClone(*repoDir, true, &git.CloneOptions{
+			URL: "https://github.com/zekoz/freeciv.git",
+		})
+	}
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	s := &codeoflaws.Server{Repo: r}
+	s.Id = "codeoflaws"
+	if !s.Start(s) {
+		glog.Exit("start failed")
+	}
+	glog.Exit(s.StartNetListener("unix", *p9SocketPath))
+}

--- a/codeoflaws/config.json
+++ b/codeoflaws/config.json
@@ -1,0 +1,34 @@
+{
+  "description": "Freeciv ruleset plugin for Docker",
+  "documentation": "https://docs.docker.com/engine/extend/plugins/",
+  "entrypoint": [
+    "/codeoflaws"
+  ],
+  "interface": {
+    "socket": "codeoflaws.sock",
+    "types": [
+      "docker.volumedriver/1.0"
+    ]
+  },
+  "mounts": [
+    {
+      "destination": "/mnt/repo",
+      "options": [
+        "rbind"
+      ],
+      "name": "repo",
+      "source": "/var/lib/docker/plugins/",
+      "settable": [
+        "source"
+      ],
+      "type": "bind"
+    }
+  ],
+  "network": {
+    "type": "host"
+  },
+  "propagatedmount": "/mnt/volumes",
+  "linux": {
+    "capabilities": ["CAP_SYS_ADMIN"]
+  }
+}

--- a/codeoflaws/docker.go
+++ b/codeoflaws/docker.go
@@ -1,0 +1,141 @@
+package codeoflaws
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+
+	"github.com/docker/go-plugins-helpers/volume"
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+)
+
+type VolumeDriver struct {
+	p9SocketPath string
+
+	sync.Mutex
+	volumes map[string]*p9Volume
+}
+
+type p9Volume struct {
+	mountPoint string
+	revision   string
+}
+
+func NewVolumeDriver(p9SocketPath string) *VolumeDriver {
+	return &VolumeDriver{
+		p9SocketPath: p9SocketPath,
+		volumes:      make(map[string]*p9Volume),
+	}
+}
+
+func (d *VolumeDriver) Create(req *volume.CreateRequest) error {
+	v := &p9Volume{}
+
+	for key, val := range req.Options {
+		switch key {
+		case "revision":
+			v.revision = val
+		default:
+		}
+	}
+
+	d.Lock()
+	d.volumes[req.Name] = v
+	d.Unlock()
+
+	return nil
+
+}
+
+func (d *VolumeDriver) Remove(req *volume.RemoveRequest) error {
+	d.Lock()
+	defer d.Unlock()
+
+	v, ok := d.volumes[req.Name]
+	if !ok {
+		return fmt.Errorf("volume %s not found", req.Name)
+	}
+
+	if err := os.RemoveAll(v.mountPoint); err != nil {
+		return err
+	}
+	delete(d.volumes, req.Name)
+	return nil
+}
+
+func (d *VolumeDriver) Path(req *volume.PathRequest) (*volume.PathResponse, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	v, ok := d.volumes[req.Name]
+	if !ok {
+		return &volume.PathResponse{}, fmt.Errorf("volume %s not found", req.Name)
+	}
+
+	return &volume.PathResponse{Mountpoint: v.mountPoint}, nil
+}
+
+func (d *VolumeDriver) Mount(req *volume.MountRequest) (*volume.MountResponse, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	v, ok := d.volumes[req.Name]
+	if !ok {
+		return &volume.MountResponse{}, fmt.Errorf("volume %s not found", req.Name)
+	}
+
+	v.mountPoint = "/mnt/volumes/" + uuid.New().String()
+	if err := os.MkdirAll(v.mountPoint, 0755); err != nil {
+		glog.Error(err)
+		return &volume.MountResponse{}, err
+	}
+
+	//if err := syscall.Mount(d.p9SocketPath, v.mountPoint, "9p", uintptr(0), "version=9p2000.L,trans=unix"); err != nil {
+	if _, err := exec.Command("/bin/mount", "-t", "9p", d.p9SocketPath, v.mountPoint, "-o", "version=9p2000.L,trans=unix").Output(); err != nil {
+		glog.Error(err)
+		return &volume.MountResponse{}, err
+	}
+
+	return &volume.MountResponse{Mountpoint: v.mountPoint}, nil
+}
+
+func (d *VolumeDriver) Unmount(req *volume.UnmountRequest) error {
+	d.Lock()
+	defer d.Unlock()
+	v, ok := d.volumes[req.Name]
+	if !ok {
+		return fmt.Errorf("volume %s not found", req.Name)
+	}
+
+	return syscall.Unmount(v.mountPoint, 0)
+}
+
+func (d *VolumeDriver) Get(req *volume.GetRequest) (*volume.GetResponse, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	v, ok := d.volumes[req.Name]
+	if !ok {
+		return &volume.GetResponse{}, fmt.Errorf("volume %s not found", req.Name)
+	}
+
+	return &volume.GetResponse{Volume: &volume.Volume{Name: req.Name, Mountpoint: v.mountPoint}}, nil
+}
+
+func (d *VolumeDriver) List() (*volume.ListResponse, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	var vols []*volume.Volume
+	for name, v := range d.volumes {
+		vols = append(vols, &volume.Volume{Name: name, Mountpoint: v.mountPoint})
+	}
+	return &volume.ListResponse{Volumes: vols}, nil
+}
+
+func (d *VolumeDriver) Capabilities() *volume.CapabilitiesResponse {
+	return &volume.CapabilitiesResponse{Capabilities: volume.Capability{Scope: "local"}}
+}

--- a/codeoflaws/server.go
+++ b/codeoflaws/server.go
@@ -1,0 +1,278 @@
+package codeoflaws
+
+import (
+	"context"
+	"encoding/binary"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/rminnich/go9p"
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/config"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+type Server struct {
+	go9p.Srv
+
+	Repo *git.Repository
+}
+
+type fid struct {
+	path     string
+	tree     *object.Tree
+	qid      go9p.Qid
+	contents []byte
+}
+
+func hashQid(hash plumbing.Hash) go9p.Qid {
+	return go9p.Qid{Path: binary.LittleEndian.Uint64(hash[0:8])}
+}
+
+func treeFileFid(tree *object.Tree, path string) (*fid, error) {
+	te, err := tree.FindEntry(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := tree.TreeEntryFile(te)
+	if err != nil {
+		return nil, err
+	}
+
+	cont, err := fi.Contents()
+	if err != nil {
+		return nil, err
+	}
+
+	return &fid{
+		path:     path,
+		qid:      hashQid(fi.Hash),
+		contents: []byte(cont),
+	}, nil
+}
+
+func (s *Server) revisionTree(rev string) (*object.Tree, error) {
+	h, err := s.Repo.ResolveRevision(plumbing.Revision(rev))
+	if err != nil {
+		return nil, err
+	}
+	if h == nil {
+		return nil, err
+	}
+
+	commit, err := s.Repo.CommitObject(*h)
+	if err != nil {
+		return nil, err
+	}
+
+	rt, err := s.Repo.TreeObject(commit.TreeHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return rt.Tree("data")
+}
+
+func (s *Server) Attach(req *go9p.SrvReq) {
+	if req.Afid != nil {
+		req.RespondError(go9p.Enoauth)
+		return
+	}
+
+	tc := req.Tc
+	rev := tc.Aname
+	if rev == "" {
+		rev = "master"
+	}
+
+	ctx := context.Background()
+	if err := s.Repo.FetchContext(ctx, &git.FetchOptions{
+		RefSpecs: []config.RefSpec{"+refs/heads/*:refs/heads/*"},
+	}); err != nil && err != git.NoErrAlreadyUpToDate {
+		glog.Error(err)
+		req.RespondError(go9p.Enoent)
+		return
+	}
+
+	t, err := s.revisionTree(rev)
+	if err != nil {
+		glog.Error(err)
+		req.RespondError(go9p.Enoent)
+		return
+	}
+	req.Fid.Aux = &fid{
+		tree: t,
+		qid:  hashQid(t.Hash),
+	}
+
+	q := hashQid(t.Hash)
+	q.Type |= go9p.QTDIR
+
+	req.RespondRattach(&q)
+}
+
+func (*Server) Clunk(req *go9p.SrvReq) { req.RespondRclunk() }
+
+func (s *Server) Remove(req *go9p.SrvReq) {
+	req.RespondError(go9p.Eperm)
+}
+
+func (s *Server) Walk(req *go9p.SrvReq) {
+	tc := req.Tc
+	f := req.Fid.Aux.(*fid)
+
+	if req.Newfid.Aux == nil {
+		req.Newfid.Aux = new(fid)
+	}
+
+	var qids []go9p.Qid
+	var err error
+
+	switch {
+	case len(tc.Wname) == 0:
+		req.Newfid.Aux = f
+	case f.path == "":
+		dt := f.tree
+		rssp := strings.Split(tc.Wname[0], "@")
+		switch len(rssp) {
+		case 1:
+		case 2:
+			if dt, err = s.revisionTree(rssp[1]); err != nil {
+				glog.Error(err)
+				req.RespondError(go9p.Enoent)
+				return
+			}
+
+		default:
+			glog.Error("invalid path: %v", tc.Wname)
+			req.RespondError(go9p.Enoent)
+			return
+		}
+
+		t, err := dt.Tree(rssp[0])
+		if err != nil {
+			glog.Error(err)
+			req.RespondError(go9p.Enoent)
+			return
+		}
+
+		tq := hashQid(t.Hash)
+		tq.Type |= go9p.QTDIR
+
+		qids = append(qids, tq)
+		switch len(tc.Wname) {
+		case 1:
+			req.Newfid.Type |= go9p.QTDIR
+			req.Newfid.Aux = &fid{
+				tree: t,
+				path: rssp[0],
+				qid:  tq,
+			}
+		case 2:
+			nf, err := treeFileFid(t, tc.Wname[1])
+			if err != nil {
+				glog.Error(err)
+				req.RespondError(go9p.Enoent)
+				return
+			}
+			req.Newfid.Aux = nf
+			qids = append(qids, nf.qid)
+		default:
+			req.RespondError(go9p.Enoent)
+			return
+		}
+
+	case f.tree != nil:
+		if len(tc.Wname) != 1 {
+			req.RespondError(go9p.Enoent)
+			return
+		}
+		nf, err := treeFileFid(f.tree, tc.Wname[0])
+		if err != nil {
+			glog.Error(err)
+			req.RespondError(go9p.Enoent)
+			return
+		}
+		req.Newfid.Aux = nf
+		qids = append(qids, nf.qid)
+	}
+
+	req.RespondRwalk(qids)
+}
+
+func (s *Server) Read(req *go9p.SrvReq) {
+	tc := req.Tc
+	rc := req.Rc
+	go9p.InitRread(rc, tc.Count)
+	f := req.Fid.Aux.(*fid)
+
+	if f.tree != nil {
+		go9p.SetRreadCount(rc, 0)
+		req.Respond()
+		return
+	}
+
+	if tc.Offset >= uint64(len(f.contents)) {
+		go9p.SetRreadCount(rc, 0)
+		req.Respond()
+		return
+
+	}
+
+	count := int(tc.Count)
+	if remaining := len(f.contents) - int(tc.Offset); remaining < count {
+		count = remaining
+	}
+
+	n := copy(rc.Data, f.contents[tc.Offset:int(tc.Offset)+count])
+	glog.Infof("contes %d, count %d, copied %d", len(f.contents), count, n)
+	go9p.SetRreadCount(rc, uint32(n))
+	req.Respond()
+}
+
+func (*Server) Write(req *go9p.SrvReq) {
+	req.RespondError(go9p.Eperm)
+}
+
+func (s *Server) Open(req *go9p.SrvReq) {
+	f := req.Fid.Aux.(*fid)
+	req.RespondRopen(&f.qid, 0)
+}
+
+func (*Server) Create(req *go9p.SrvReq) {
+	req.RespondError(go9p.Eperm)
+}
+
+func (s *Server) Stat(req *go9p.SrvReq) {
+	f := req.Fid.Aux.(*fid)
+
+	d := &go9p.Dir{}
+
+	if f.path == "" {
+		d.Name = "data"
+	} else {
+		d.Name = f.path
+	}
+	d.Qid = f.qid
+	d.Uid = "root"
+	d.Gid = "root"
+	d.Mode = 0755
+	t := time.Now()
+	d.Atime = uint32(t.Unix())
+	d.Mtime = uint32(t.Unix())
+
+	if f.tree == nil {
+		d.Length = uint64(len(f.contents))
+	} else {
+		d.Mode |= go9p.DMDIR
+	}
+
+	req.RespondRstat(d)
+}
+
+func (*Server) Wstat(req *go9p.SrvReq) {
+	req.RespondRwstat()
+}


### PR DESCRIPTION
I propose to make ruleset management easier on freeciv-web. Right now, rulesets are manually managed and versioned, and the only way to handle multiple version of the same ruleset is to make copies, like for each longturn game running. The proposed solution is to be able to specify rulesetdir like /rulesetdir civ2@git-revision, and this 9p file server and docker volume plugin enable this use case.

This will make it possible for users to make pull requests to github repo and then play their rulesets on public servers without any work other than an owner or bot accepting a pull request.