### PR TITLE
Separate keyhandlers

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/city.js
+++ b/freeciv-web/src/main/webapp/javascript/city.js
@@ -216,6 +216,7 @@ function show_city_dialog(pcity)
                        "restore" : "ui-icon-bullet"
                      }});
 
+  $("#city_dialog").dialog('widget').keydown(city_keyboard_listener);
   $("#city_dialog").dialog('open');
   $("#game_text_input").blur();
 
@@ -1980,10 +1981,12 @@ function city_keyboard_listener(ev)
      switch (keyboard_key) {
        case 'N':
          next_city();
+         ev.stopPropagation();
          break;
 
        case 'B':
          request_city_buy();
+         ev.stopPropagation();
          break;
       }
   }

--- a/freeciv-web/src/main/webapp/javascript/civclient.js
+++ b/freeciv-web/src/main/webapp/javascript/civclient.js
@@ -124,6 +124,7 @@ function civclient_init()
   if (renderer == RENDERER_WEBGL) init_webgl_renderer();
 
   game_init();
+  $('#tabs').tabs({ heightStyle: "fill" });
   control_init();
   init_replay();
 
@@ -159,7 +160,6 @@ function civclient_init()
   }
 
 
-  $('#tabs').tabs({ heightStyle: "fill" });
   $('#tabs').css("height", $(window).height());
   $("#tabs-map").height("auto");
   $("#tabs-civ").height("auto");

--- a/freeciv-web/src/main/webapp/javascript/client_main.js
+++ b/freeciv-web/src/main/webapp/javascript/client_main.js
@@ -387,7 +387,7 @@ function set_default_mapview_active()
 
   if (!is_small_screen() && overview_active) {
     $("#game_overview_panel").parent().show();
-    $(".overview_dialog").position({my: 'left bottom', at: 'left bottom', of: window, within: $("#game_page")});
+    $(".overview_dialog").position({my: 'left bottom', at: 'left bottom', of: window, within: $("#tabs-map")});
     if (overview_current_state == "minimized") $("#game_overview_panel").dialogExtend("minimize");
   }
 

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -1113,7 +1113,8 @@ function init_game_unit_panel()
 			resizable: false,
 			closeOnEscape: false,
 			dialogClass: 'unit_dialog  no-close',
-			position: {my: 'right bottom', at: 'right bottom', of: window, within: $("#game_page")},
+			position: {my: 'right bottom', at: 'right bottom', of: window, within: $("#tabs-map")},
+			appendTo: '#tabs-map',
 			close: function(event, ui) { unitpanel_active = false;}
 
 		}).dialogExtend({

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -71,7 +71,6 @@ function control_init()
   }
 
   $(document).keydown(keyboard_listener);
-  $(document).keydown(city_keyboard_listener);
   $(window).resize(mapview_window_resized);
   $(window).bind('orientationchange resize', orientation_changed);
 

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -254,14 +254,8 @@ function control_init()
   $('#nations_list').on('click', 'tbody tr', handle_nation_table_select);
 
   /* prevents keyboard input from changing tabs. */
-  $('#tabs').tabs({
-    activate: function (event, ui) {
-        ui.newTab.blur();
-    }
-  });
-  $('#tabs a').click(function () {
-    $(this).blur();
-  });
+  $('#tabs>ul>li').off('keydown');
+  $('#tabs>div').off('keydown');
 }
 
 /****************************************************************************

--- a/freeciv-web/src/main/webapp/javascript/overview.js
+++ b/freeciv-web/src/main/webapp/javascript/overview.js
@@ -59,6 +59,7 @@ function init_overview()
   $("#game_overview_panel").dialog({
 			bgiframe: true,
 			modal: false,
+			appendTo: '#tabs-map',
 			resizable: false,
 			closeOnEscape: false,
 			dialogClass: 'overview_dialog no-close',
@@ -85,7 +86,7 @@ function init_overview()
                       if (new_height > max_overview_height) new_height = max_overview_height;
                       $('#overview_map').width(new_width);
                       $('#overview_map').height(new_height);
-                      $(".overview_dialog").position({my: 'left bottom', at: 'left bottom', of: window, within: $("#game_page")});
+                      $(".overview_dialog").position({my: 'left bottom', at: 'left bottom', of: window, within: $("#tabs-map")});
                     },
                   "icons" : {
                     "minimize" : "ui-icon-circle-minus",
@@ -106,7 +107,7 @@ function init_overview()
   if (new_height > max_overview_height) new_height = max_overview_height;
   $('#overview_map').width(new_width);
   $('#overview_map').height(new_height);
-  $(".overview_dialog").position({my: 'left bottom', at: 'left bottom', of: window, within: $("#game_page")});
+  $(".overview_dialog").position({my: 'left bottom', at: 'left bottom', of: window, within: $("#tabs-map")});
 
   $('#overview_map').on('dragstart', function(event) { event.preventDefault(); });
 }

--- a/freeciv-web/src/main/webapp/webclient/game.jsp
+++ b/freeciv-web/src/main/webapp/webclient/game.jsp
@@ -22,7 +22,7 @@
                 		</div>
 			</ul>
 			
-			<div id="tabs-map">
+			<div id="tabs-map" tabindex="-1">
 			  <jsp:include page="canvas.jsp" flush="false"/>
 			</div>
 			<div id="tabs-civ">


### PR DESCRIPTION
Split the global/map/city dialog key handlers, so that B doesn't trigger the build city action when a settler is in the selected list but you are in the city dialog and want to buy production, or have an accident in some other tab.