### PR TITLE
Support ruleset change in PBEM

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/hotseat.js
+++ b/freeciv-web/src/main/webapp/javascript/hotseat.js
@@ -92,12 +92,7 @@ function new_hotseat_game()
 function setup_hotseat_game() 
 {
   if (ws != null && ws.readyState === 1) {
-    send_message("/set phasemode player");
-    send_message("/set minp 2");
-    send_message("/set ec_chat=enabled");
-    send_message("/set ec_info=enabled");
-    send_message("/set ec_max_size=20000");
-    send_message("/set ec_turns=32768");
+    set_alternate_turns();
     send_message("/set autotoggle disabled");
     hotseat_players.push($("#username_req_1").val());
     for (var i = 2; i <= num_hotseat_players; i++) {

--- a/freeciv-web/src/main/webapp/javascript/pregame.js
+++ b/freeciv-web/src/main/webapp/javascript/pregame.js
@@ -37,12 +37,29 @@ function pregame_start_game()
 {
   if (client.conn['player_num'] == null) return;
 
+  if (is_pbem() || is_hotseat()) {
+    set_alternate_turns();
+  }
+
   var test_packet = {"pid" : packet_player_ready, "is_ready" : true,
                      "player_no": client.conn['player_num']};
   var myJSONText = JSON.stringify(test_packet);
   send_request(myJSONText);
 
   setup_window_size ();
+}
+
+/****************************************************************************
+  Set some parameters needed for alternate turns game type.
+****************************************************************************/
+function set_alternate_turns()
+{
+  send_message("/set phasemode player");
+  send_message("/set minp 2");
+  send_message("/set ec_chat=enabled");
+  send_message("/set ec_info=enabled");
+  send_message("/set ec_max_size=20000");
+  send_message("/set ec_turns=32768");
 }
 
 /****************************************************************************
@@ -514,7 +531,7 @@ function pregame_settings()
       "     <li><a href='#pregame_settings_tabs-3'>Other</a></li>" +
       "   </ul>"
       + "<div id='pregame_settings_tabs-1'><table id='settings_table'> "
-      + "<tr class='not_pbem' title='Ruleset version'><td>Ruleset:</td>"
+      + "<tr title='Ruleset version'><td>Ruleset:</td>"
       + "<td><select name='ruleset' id='ruleset'>"
       + "<option value='classic'>Classic</option>"
       + "<option value='civ2civ3'>Civ2Civ3</option>"


### PR DESCRIPTION
There's no UI for ruleset selection in PBEM games. The player can set it through the chat line, though, but will not notice that phasemode has been changed and will probably start a PBEM game in concurrent mode, which won't advance much. The same problem exists in hotseat games, despite having the UI to change ruleset.

The player can and should `/set phasemode player` after changing ruleset, but it'd be better if they didn't have to, so let's do it for them.