### PR TITLE
Update Travis to Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 language: c
 


### PR DESCRIPTION
Builds began failing tonight, due to issues updating Oracle JDK 8 during Travis build.

This patch updates the Travis build to Xenial ([recently released](https://blog.travis-ci.com/2018-11-08-xenial-release) on Travis), which has updated versions that are not failing.

Given the Vagrant box uses Bionic (2018), upgrading from Trusty (2014) to Xenial (2016) on the CI server should not present an issue.