### PR TITLE
Cleanup status script

### DIFF
--- a/freeciv/dl_freeciv_default.sh
+++ b/freeciv/dl_freeciv_default.sh
@@ -1,16 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 # Places the specified revision of Freeciv in freeciv/freeciv/
 # This is the default. The script dl_freeciv.sh will run instead of
 # dl_freeciv_default.sh if it exists.
 # If you want to modify this file copy it to dl_freeciv.sh and edit it.
 
+echo "Updating freeciv to commit $1"
+
 # Remove old version
+echo "  removing existing source"
 rm -Rf freeciv
 
 # Download the wanted Freeciv revision from GitHub unless it is here already.
 # The download step saves having to merge in Freeciv's history each time the
 # Freeciv server revision is updated.
+echo "  fetching missing revisions"
 git cat-file -e $1 || git fetch --no-tags https://github.com/freeciv/freeciv.git master:freeciv_master
 
 # Place the requested Freeciv revision in the freeciv/freeciv folder.
@@ -18,6 +22,7 @@ git cat-file -e $1 || git fetch --no-tags https://github.com/freeciv/freeciv.git
 # applied during the build won't accidentally end up in commits. It also
 # means that committing unrelated changes won't accidentally revert the
 # Freeciv server revision because a command didn't run.
+echo "  checking out commit $1"
 git read-tree --prefix=freeciv/freeciv/ --index-output=.freeciv_index $1
 mkdir freeciv && cd freeciv && GIT_INDEX_FILE=.freeciv_index git checkout-index -af && cd ..
 rm -f ../.freeciv_index

--- a/freeciv/prepare_freeciv.sh
+++ b/freeciv/prepare_freeciv.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-
 cd "${DIR}"
 
 # Fix line endings on Windows
@@ -11,12 +10,12 @@ sed -i 's/\r$//' freeciv-web.project
 
 # Allow the user to override how Freeciv is downloaded.
 if test -f dl_freeciv.sh ; then
-  FC_DL=dl_freeciv.sh
+  DL_FREECIV=dl_freeciv.sh
 else
-  FC_DL=dl_freeciv_default.sh
+  DL_FREECIV=dl_freeciv_default.sh
 fi
 
-if ! sh $FC_DL $FCREV ; then
+if ! ./$DL_FREECIV $FCREV ; then
   echo "Git checkout failed" >&2
   exit 1
 fi
@@ -27,6 +26,5 @@ if ! ./apply_patches.sh ; then
 fi
 
 ( cd freeciv
-
   ./autogen.sh CFLAGS="-O3" --enable-mapimg=magickwand --with-project-definition=../freeciv-web.project --enable-fcweb --enable-json --disable-delta-protocol --disable-nls --disable-fcmp --enable-freeciv-manual --disable-ruledit --enable-fcdb=no --enable-ai-static=classic,threaded --prefix=${HOME}/freeciv/ && make -s -j$(nproc)
 )

--- a/scripts/install/dependency-services-default-start.sh
+++ b/scripts/install/dependency-services-default-start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Start Freeciv-web's dependency services.
 #
@@ -21,7 +21,6 @@ then
   echo "nginx already running!"
   sudo nginx -s reload
 else
-  echo "Please enter root password:"
   sudo service nginx start && \
   echo "nginx started!" && \
   sleep 1

--- a/scripts/install/dependency-services-systemd-start.sh
+++ b/scripts/install/dependency-services-systemd-start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Use systemd to start the services Freeciv-web depends on.
 # Need to start the dependency services in a different way to work with

--- a/scripts/install/dependency-services-systemd-stop.sh
+++ b/scripts/install/dependency-services-systemd-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Use systemd to stop the services Freeciv-web depends on.
 # Need to start the dependency services in a different way to work with
@@ -15,4 +15,3 @@ systemctl is-active --quiet nginx.service && ${ACCESS_MANAGER} systemctl reload 
 if [ "${TOMCATMANAGER}" != "Y" ]; then
   systemctl is-active --quiet tomcat8.service && ${ACCESS_MANAGER} systemctl stop tomcat8.service
 fi
-

--- a/scripts/start-freeciv-web.sh
+++ b/scripts/start-freeciv-web.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 # Startup script for running all processes of Freeciv-web
 
-SCRIPT_DIR="$(dirname "$0")"
-cd "$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd ${SCRIPT_DIR}
+
 export FREECIV_WEB_DIR="${SCRIPT_DIR}/.."
 export FREECIV_DATA_PATH="${HOME}/freeciv/share/freeciv/"
 export LC_ALL=en_US.UTF-8

--- a/scripts/status-freeciv-web.sh
+++ b/scripts/status-freeciv-web.sh
@@ -2,6 +2,14 @@
 # Checks status of various Freeciv-web processes
 
 alias curl='stdbuf -i0 -o0 -e0 curl'
+verbose=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -v) verbose=true; shift; shift;;
+    *) shift;;
+  esac
+done
 
 # Some versions of Curl will by default change the formatting of headers
 # when printing them to the terminal. A bug will then cause Curl to not turn
@@ -12,113 +20,108 @@ alias curl='stdbuf -i0 -o0 -e0 curl'
 # unknown option.
 work_around_curl_console_output_bug () {
   # reset the terminal formatting
-  echo -e "\e[0m"
+  echo -ne "\e[0m"
 }
 
 checkURL () {
   local URL=$1
-  local logfile=$2
+  shift 1
+  curl --no-buffer --silent --show-error --fail --insecure "$@" "${URL}"
+}
+checkWS () {
+  local URL=$1
+  shift 1
+  curl --include --no-buffer --silent --show-error \
+    -H "Connection: Upgrade" \
+    -H "Upgrade: websocket" \
+    -H "Host: localhost" \
+    -H "Origin: http://localhost" \
+    -H "Sec-WebSocket-Version: 13" \
+    -H 'Sec-WebSocket-Key: +onQ3ZxjWlkNa0na6ydhNg==' \
+    --max-time 2 "$@" "${URL}"
+  local status=$?
+  work_around_curl_console_output_bug
+
+  if [[ ${status} -eq 28 ]]; then # timeout - expected for websockets
+    return 0
+  elif [[ ${status} -eq 0 ]]; then
+    return -1
+  else
+    return ${status}
+  fi
+}
+checkWebURL () { # description, URL, curl-params
+  local description="$1"
+  local URL=$2
   shift 2
-  curl --no-buffer --silent --show-error --fail --insecure "$@" -o "${logfile}" "${URL}" >> "${logfile}" 2>&1
+
+  checkWebStatus "${description}" "" checkURL "${URL}" "$@"
+}
+checkWebSocket () { # description, URL, curl-params
+  local description="$1"
+  local URL=$2
+  shift 2
+  local err_msg="Expected \"HTTP/1.1 101 Switching Protocols\" followed by timeout after 2 seconds."
+
+  checkWebStatus "${description}" "${err_msg}" checkWS "${URL}" "$@"
+}
+checkWebStatus () { # description, err_msg, testFn, URL, curl-params
+  local description="$1"
+  local err_msg="$2"
+  local testFn="$3"
+  local URL="$4"
+  shift 4
+
+  if [[ "${verbose}" = true ]]; then
+    description="${description} (${URL})"
+  fi
+  checkStatus "${description}" "${err_msg}" "${testFn}" "${URL}" "$@"
+}
+checkPID () { # description, program
+  local description="$1"
+  local program="$2"
+  checkStatus "${description}" "" pidof "${program}"
+}
+checkService () { # service
+  checkStatus "$1" "" /usr/sbin/service "$1" status
+}
+checkStatus () { # description, err_msg, <function and args...>
+  local description="$1"
+  local err_msg="$2"
+  shift 2
+  local logfile=$(mktemp /tmp/status.XXXXXX.log)
+
+  printf "%-50s " "Checking ${description}"
+  if "$@" > "${logfile}" 2>&1; then
+    printf "OK!\n"
+  else
+    printf "Down\n"
+    if [[ "${verbose}" = true ]]; then
+      [[ -n "${err_msg}" ]] && echo "  ${err_msg}"
+      cat "${logfile}" | sed 's/^/  /'; echo
+    fi
+  fi
+  rm "${logfile}"
 }
 
-rm -f /tmp/status[1-7].log
-printf "Checking that Freeciv-web is running correctly... \n\n\n"
-printf "checking nginx on http://localhost\n"
-if checkURL http://localhost /tmp/status1.log --head; then
-  echo "nginx OK!"
-else
-  cat /tmp/status1.log
-  echo "nginx not running!"
-fi
 
-printf "\n--------------------------------\n";
+printf "Checking that Freeciv-web is running correctly... (-v for verbose)\n\n"
 
-printf "checking Tomcat on http://localhost:8080/\n"
-if checkURL http://localhost:8080/ /tmp/status2.log --head; then
-  echo "Tomcat OK!"
-else
-  cat /tmp/status2.log
-  echo "Tomcat not running!"
-fi
+checkService "nginx"
 
-printf "checking freeciv-web on Tomcat on http://localhost:8080/freeciv-web\n"
-if checkURL http://localhost:8080/freeciv-web /tmp/status2.log --head; then
-  echo "freeciv-web webapp OK!"
-else
-  cat /tmp/status2.log
-  echo "freeciv-web webapp not running!"
-fi
+checkWebURL "Tomcat" "http://localhost:8080/" --head
+checkWebURL "freeciv-web on Tomcat" "http://localhost:8080/freeciv-web" --head
 
-printf "\n--------------------------------\n";
+checkWebURL "freeciv-proxy directly" "http://localhost:7001/status"
+checkWebURL "freeciv-proxy through nginx" "http://localhost/civsocket/7001/status"
 
-echo "checking freeciv-proxy directly on http://localhost:7001/status"
-if checkURL http://localhost:7001/status /tmp/status3.log; then
-  echo "freeciv-proxy OK!"
-else
-  cat /tmp/status3.log
-  echo "freeciv-proxy not running!"
-fi
+checkWebSocket "WebSocket directly (freeciv-proxy)" "http://localhost:7002/civsocket/7002"
+checkWebSocket "WebSocket through nginx" "http://localhost/civsocket/7002"
 
-printf "\n--------------------------------\n";
-echo "checking freeciv-proxy through nginx on http://localhost/civsocket/7001/status"
-if checkURL http://localhost/civsocket/7001/status /tmp/status4.log; then
-  echo "freeciv-proxy OK!"
-else
-  cat /tmp/status4.log
-  echo "freeciv-proxy not running correctly through nginx!"
-fi
+checkPID "freeciv-web (spawned by publite2)" "freeciv-web"
 
-printf "\n--------------------------------\n";
-
-echo "testing WebSocket connection directly to Tornado"
-echo "This should show \"HTTP/1.1 101 Switching Protocols\" and then timeout after 2 seconds."
-curl -isSN -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Host: localhost" -H "Origin: http://localhost" -H "Sec-WebSocket-Version: 13" -H 'Sec-WebSocket-Key: +onQ3ZxjWlkNa0na6ydhNg==' --max-time 2  http://localhost:7002/civsocket/7002
-work_around_curl_console_output_bug
-
-echo "testing WebSocket connection through nginx"
-echo "This should show \"HTTP/1.1 101 Switching Protocols\" and then timeout after 2 seconds."
-curl -isSN -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Host: localhost" -H "Origin: http://localhost" -H "Sec-WebSocket-Version: 13" -H 'Sec-WebSocket-Key: +onQ3ZxjWlkNa0na6ydhNg==' --max-time 2  http://localhost/civsocket/7002
-work_around_curl_console_output_bug
-printf "\n--------------------------------\n ";
-
-echo "checking freeciv-web / publite2"
-if [ "$(pidof freeciv-web)" ] 
-then
-  echo "freeciv-web OK!"
-else
-  echo "freeciv-web not running"
-fi
-
-printf "\n--------------------------------\n";
-
-echo "checking that webclient.min.js has been generated..."
-if checkURL http://localhost/javascript/webclient.min.js /tmp/status5.log --head; then
-  echo "webclient.min.js is OK!"
-else
-  cat /tmp/status5.log
-  echo "webclient.min.js is not OK"
-fi
-
-printf "\n--------------------------------\n";
-
-echo "checking that tileset has been generated..."
-if checkURL http://localhost/tileset/freeciv-web-tileset-amplio2-0.png /tmp/status6.log --head; then
-  echo "tileset is OK!"
-else
-  cat /tmp/status6.log
-  echo "tileset is not OK"
-fi
-
-printf "\n--------------------------------\n";
-
-echo "checking metaserver on PHP server..."
-if checkURL http://localhost/game/list /tmp/status7.log --head; then
-  echo "metaserver is OK!"
-else
-  cat /tmp/status7.log
-  echo "metaserver is not OK"
-fi
+checkWebURL "webclient.min.js generation" "http://localhost/javascript/webclient.min.js" --head
+checkWebURL "tileset generation" "http://localhost/tileset/freeciv-web-tileset-amplio2-0.png" --head
 
 printf "\n--------------------------------\n";
 echo "Check of Freeciv-web is done!"

--- a/scripts/stop-freeciv-web.sh
+++ b/scripts/stop-freeciv-web.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Shutdown script for Freeciv-web
 
-SCRIPT_DIR="$(dirname "$0")"
-cd "$(dirname "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd ${SCRIPT_DIR}
+
 export FREECIV_WEB_DIR="${SCRIPT_DIR}/.."
 
 if [ ! -f ${SCRIPT_DIR}/configuration.sh ]; then
@@ -35,7 +36,6 @@ killall -9 freeciv-web
 
 
 #4. freeciv-proxy
-
 ps aux | grep -ie freeciv-proxy | awk '{print $2}' | xargs kill -9 
 
 #5.1 Freeciv-PBEM


### PR DESCRIPTION
While working updating to freeciv server, I found these changes useful.

Overall status will appear as:
```
vagrant@ubuntu-bionic:/vagrant/freeciv-web$ ../scripts/status-freeciv-web.sh
Checking that Freeciv-web is running correctly... (-v for verbose)

Checking nginx                                     OK!
Checking Tomcat                                    OK!
Checking freeciv-web on Tomcat                     OK!
Checking freeciv-proxy directly                    OK!
Checking freeciv-proxy through nginx               OK!
Checking WebSocket directly to Tornado             OK!
Checking WebSocket through nginx                   OK!
Checking freeciv-web / publite2                    OK!
Checking webclient.min.js generation               OK!
Checking tileset generation                        OK!
Checking metaserver on PHP server                  OK!

--------------------------------
Check of Freeciv-web is done!
```