### PR TITLE
Separate longturn savegames

### DIFF
--- a/publite2/init-freeciv-web.sh
+++ b/publite2/init-freeciv-web.sh
@@ -13,19 +13,22 @@ if [ $5 = "pbem" ]; then
    pbemcmd="--Ranklog /var/lib/tomcat8/webapps/data/ranklogs/rank_${2}.log "
 fi
 
+savesdir=${1}
 quitidle=" -q 20"
 if [[ $6 == *"longturn"* ]]; then
   quitidle=" "
+  savesdir="${savesdir}/lt/${6}"
+  mkdir -p "${savesdir}"
 fi
 
-export FREECIV_SAVE_PATH=${1};
+export FREECIV_SAVE_PATH=${savesdir};
 rm -f /var/lib/tomcat8/webapps/data/scorelogs/score-${2}.log; 
 
 python3 ../freeciv-proxy/freeciv-proxy.py ${3} > ../logs/freeciv-proxy-${3}.log 2>&1 &
 proxy_pid=$! && 
 ${HOME}/freeciv/bin/freeciv-web --debug=1 --port ${2} --keep ${quitidle} --Announce none -e  -m \
 -M http://${4} --type ${5} --read pubscript_${6}.serv --log ../logs/freeciv-web-log-${2}.log \
---saves ${1} ${pbemcmd:- } > /dev/null 2> ../logs/freeciv-web-stderr-${2}.log;
+--saves "${savesdir}" ${pbemcmd:- } > /dev/null 2> ../logs/freeciv-web-stderr-${2}.log;
 
 rc=$?; 
 kill -9 $proxy_pid; 


### PR DESCRIPTION
Make a new directory lt/game_name so that longturn type savegames don't get all mixed in the root data savegames directory. This way they are easier to track and to reload in case of server restart.