### PR TITLE
Improve Dockerfile and add docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.dockerignore
+.gitattributes
+.gitignore
+.mailmap
+.travis.yml
+ADVANCED.md
+CONTRIBUTING.md
+Dockerfile
+README.md
+README-One-Turn-Per-Day.md
+TODO
+Vagrantfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,55 +5,58 @@ FROM debian:stretch
 
 MAINTAINER The Freeciv Project version: 2.5
 
-## Add relevant content - to be pruned in the future
+RUN DEBIAN_FRONTEND=noninteractive apt-get update --yes --quiet && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+        sudo \
+        lsb-release \
+        locales && \
+    DEBIAN_FRONTEND=noninteractive apt-get clean --yes && \
+    rm --recursive --force /var/lib/apt/lists/*
 
-ADD .git /docker/.git
-ADD freeciv /docker/freeciv
-ADD freeciv-earth /docker/freeciv-earth
-ADD freeciv-proxy /docker/freeciv-proxy
-ADD freeciv-web /docker/freeciv-web
-ADD pbem /docker/pbem
-ADD publite2 /docker/publite2
-ADD LICENSE.txt /docker/LICENSE.txt
+RUN DEBIAN_FRONTEND=noninteractive locale-gen en_US.UTF-8 && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-ADD scripts /docker/scripts
-ADD tests /docker/tests
-ADD music /docker/music
-ADD blender /docker/blender
-ADD nginx /docker/nginx
-ADD config /docker/config
-
-## Install relevant packages
-
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get -y upgrade && apt-get install -y \
-    sudo \
-    lsb-release \
-    locales
-
-EXPOSE 80 8080 4002 6000 6001 6002 7000 7001 7002
-
-## Fix locate issues
-
-RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-
-ENV LANG en_US.UTF-8 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 ## Create user and ensure no passwd questions during scripts
+RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo && \
+    echo "docker ALL = (root) NOPASSWD: ALL\n" > /etc/sudoers.d/docker && \
+    chmod 0440 /etc/sudoers.d/docker
 
-RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
-RUN echo "docker ALL = (root) NOPASSWD: ALL" >> /etc/sudoers.d/docker
-RUN chmod 0440 /etc/sudoers.d/docker
+## Add relevant content - to be pruned in the future
+COPY .git /docker/.git
+COPY freeciv /docker/freeciv
+COPY freeciv-earth /docker/freeciv-earth
+COPY freeciv-proxy /docker/freeciv-proxy
+COPY freeciv-web /docker/freeciv-web
+COPY pbem /docker/pbem
+COPY publite2 /docker/publite2
+COPY LICENSE.txt /docker/LICENSE.txt
+
+COPY scripts /docker/scripts
+COPY tests /docker/tests
+COPY music /docker/music
+COPY blender /docker/blender
+COPY nginx /docker/nginx
+COPY config /docker/config
 
 RUN chown -R docker:docker /docker
 
 USER docker
-ENV LC_ALL C.UTF-8
 
 WORKDIR /docker/scripts/
 
-RUN install/install.sh --mode=TEST
-RUN sudo rm /etc/sudoers.d/docker
+RUN DEBIAN_FRONTEND=noninteractive sudo apt-get update --yes --quiet && \
+    DEBIAN_FRONTEND=noninteractive install/install.sh --mode=TEST && \
+    DEBIAN_FRONTEND=noninteractive sudo apt-get clean --yes && \
+    sudo rm --recursive --force /var/lib/apt/lists/*
+
+COPY docker-entrypoint.sh /docker/docker-entrypoint.sh
+
+EXPOSE 80 8080 4002 6000 6001 6002 7000 7001 7002
+
+ENTRYPOINT ["/docker/docker-entrypoint.sh"]
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿THE FREECIV-WEB PROJECT
+THE FREECIV-WEB PROJECT
 -----------------------
 
 [![Build Status](https://api.travis-ci.org/freeciv/freeciv-web.png)](https://travis-ci.org/freeciv/freeciv-web)
@@ -164,27 +164,25 @@ Start and stop Freeciv-web with the following commands:
 
 All software components in Freeciv-web will log to the /logs sub-directory of the Freeciv-web installation.
 
-### Freeciv-Web alternative Docker image
 
-1. Build local dockerfile based on debian - this will take a significant amount of time (10 - 20 minutes)
+### Running Freeciv-web on Docker
 
-docker build . -t freeciv-web
+Freeciv-web can easily be built and run from Docker using `docker-compose`.
 
-2. Run docker image including required ports on your host
+ 1. Make sure you have both [Docker](https://www.docker.com/get-started) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
 
-docker run -i -t --user docker -p 8888:8080 -p 80:80 -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 6000:6000 -p 6001:6001 -p 6002:6002 freeciv-web
+ 2. Run the following from the freeciv-web directory:
 
-3. Start Freeciv-web with:
+    ```sh
+    docker-compose up -d
+    ```
 
-./start-freeciv-web.sh
-
-Answer prompt for docker sudo password with "docker"
-
-4. Connect to docker via host machine using standard browser
+ 3. Connect to docker via host machine using standard browser
 
 http://localhost/
 
 Enjoy. The overall dockerfile and required changes to scripts needs some further improvements.
+
 
 Freeciv-Web continuous integration on Travis CI 
 -----------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+
+  freeciv-web:
+    image: freeciv/freeciv-web
+    build: .
+    container_name: freeciv-web
+    command: ["sleep", "infinity"]
+    ports:
+      - "80"
+      - "4002"
+      - "6000"
+      - "6001"
+      - "6002"
+      - "7000"
+      - "7001"
+      - "7002"
+      - "8888:8080"
+    user: docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,15 @@ services:
     build: .
     container_name: freeciv-web
     command: ["sleep", "infinity"]
+    volumes:
+      - "data:/var/lib/tomcat8/webapps/data"
     ports:
       - "80"
       - "4002"
-      - "6000"
-      - "6001"
-      - "6002"
-      - "7000"
-      - "7001"
-      - "7002"
+      - "6000-6009:6000-6009"
+      - "7000-7009:7000-7009"
       - "8888:8080"
     user: docker
+
+volumes:
+  data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+/docker/scripts/start-freeciv-web.sh
+
+exec "$@"


### PR DESCRIPTION
Made some improvements to the Docker stuff.

  - Made improvements to the Dockerfile in line with the [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and personal experience.
      - Changed `ADD` to `COPY` because that is more concise.
      - Removed `apt-get upgrade` because it's not recommended.
      - Added removal of cache files to reduce image size.
      - Put all the generic and slower commands before the quick commands to prevent that everything is rerun every time a file changes.
  - Keep `docker` user in `sudoers` to prevent it asking for password when starting the start script.
  - Added `docker-entrypoint.sh` which automatically starts freeciv when starting the container.
  - Created `docker-compose.yml` to easily start container with docker-compose.
  - Added `.dockerignore` file.