### PR TITLE
tomcat: accept utf8 as default

### DIFF
--- a/freeciv-web/src/main/webapp/WEB-INF/web.xml
+++ b/freeciv-web/src/main/webapp/WEB-INF/web.xml
@@ -5,6 +5,21 @@
 
 	<display-name>Freeciv-web Client</display-name>
 
+	<filter>
+		<filter-name>setCharacterEncodingFilter</filter-name>
+		<filter-class>org.apache.catalina.filters.SetCharacterEncodingFilter</filter-class>
+		<init-param>
+			<param-name>encoding</param-name>
+			<param-value>UTF-8</param-value>
+		</init-param>
+		<async-supported>true</async-supported>
+	</filter>
+
+	<filter-mapping>
+		<filter-name>setCharacterEncodingFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+
 	<resource-ref>
 		<description>MySQL DB Connection</description>
 		<res-ref-name>jdbc/freeciv_mysql</res-ref-name>


### PR DESCRIPTION
This fixes a problem with non-US-ASCII characters in player and nation names reported from freeciv to the metaserver. It's been in real use for several weeks, but I don't known if it's The Right Way.
- Maybe it breaks setups running freeciv with a different encoding.
- Maybe freeciv should be changed to tell the encoding it is using when sending data to the metaserver.
- Maybe the filter should be applied only to the metaserver URL.
- Maybe...