### PR TITLE
Restore a missing getter function

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/civclient.js
+++ b/freeciv-web/src/main/webapp/javascript/civclient.js
@@ -662,3 +662,11 @@ function is_longturn()
 {
   return game_type == "longturn";
 }
+
+/**************************************************************************
+ Is this an ongoing LongTurn game?
+*************************************************************************/
+function is_ongoing_longturn()
+{
+  return is_longturn() && game_info['turn'] > 0;
+}


### PR DESCRIPTION
Sadly, during my resubmitting of the feature, I forgot to include this file with the getter function.