### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY freeciv-web /docker/freeciv-web
 COPY pbem /docker/pbem
 COPY publite2 /docker/publite2
 COPY LICENSE.txt /docker/LICENSE.txt
+COPY requirements.txt /docker/requirements.txt
 
 COPY scripts /docker/scripts
 COPY tests /docker/tests


### PR DESCRIPTION
`docker-compose up -d` fails because "/docker/requirements.txt" doesn't exist inside the image.
This small fix addressed the issue for me.

Keep up the awesome work on freeciv-web :)