### PR TITLE
Fix: run apt-get in noninteractive mode

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -51,9 +51,8 @@ dependencies="\
   zlib1g-dev \
 "
 
-export DEBIAN_FRONTEND=noninteractive
 INSTALLED_TOMCAT=N
-APT_GET='apt-get -y -qq -o=Dpkg::Use-Pty=0'
+APT_GET='DEBIAN_FRONTEND=noninteractive apt-get -y -qq -o=Dpkg::Use-Pty=0'
 
 sudo ${APT_GET} update
 


### PR DESCRIPTION
Some updates may ask questions to the user, but running under Vagrant
and other unattended provisioners there may not be a way to do so.

DEBIAN_FRONTEND was already set as "noninteractive", but sudo rightfully
slashes the environment and passes only a handful of variables, so apt-get
was not seeing that value.

Closes #285