### PR TITLE
Let non sudo users start and stop Freeciv-web.

### DIFF
--- a/config/config.dist
+++ b/config/config.dist
@@ -29,6 +29,11 @@ TOMCATMANAGER=N
 TOMCATMANAGER_USER=tomcat-user
 TOMCATMANAGER_PASSWORD=
 
+# If the user running Freeciv-web don't have access to sudo set this to N
+# so shutting down Freeciv-web won't cause stop-freeciv-web.sh to try to
+# disable Freeciv-web in NGINX by deleting it from /etc/nginx/sites-enabled/
+NGINX_DISABLE_ON_SHUTDOW=Y
+
 # Mail server
 # Login and password are used for authentication to the SMTP server, the default
 # is no auth.

--- a/config/scripts.tmpl
+++ b/config/scripts.tmpl
@@ -16,3 +16,7 @@ TOMCATMANAGER=#TOMCATMANAGER#
 TOMCATMANAGER_USER=#TOMCATMANAGER_USER#
 TOMCATMANAGER_PASSWORD=#TOMCATMANAGER_PASSWORD#
 
+# If the user running Freeciv-web don't have access to sudo set this to N
+# so shutting down Freeciv-web won't cause stop-freeciv-web.sh to try to
+# disable Freeciv-web in NGINX by deleting it from /etc/nginx/sites-enabled/
+NGINX_DISABLE_ON_SHUTDOW=#NGINX_DISABLE_ON_SHUTDOW#

--- a/scripts/start-freeciv-web.sh
+++ b/scripts/start-freeciv-web.sh
@@ -19,7 +19,10 @@ fi
 echo "Starting up Freeciv-web: nginx, tomcat, publite2, freeciv-proxy."
 
 mkdir -p ${FREECIV_WEB_DIR}/logs
-sudo ln -f /etc/nginx/sites-available/freeciv-web /etc/nginx/sites-enabled/freeciv-web
+if [ ! -f /etc/nginx/sites-enabled/freeciv-web ]; then
+    # Not enabled. Try to enable Freeciv-web.
+    sudo ln -f /etc/nginx/sites-available/freeciv-web /etc/nginx/sites-enabled/freeciv-web
+fi
 
 # Start Freeciv-web's dependency services according to the users
 # configuration.

--- a/scripts/stop-freeciv-web.sh
+++ b/scripts/stop-freeciv-web.sh
@@ -24,7 +24,9 @@ url="http://${TOMCATMANAGER_USER}:${TOMCATMANAGER_PASSWORD}@localhost:8080/manag
 EOF
 fi
 
-sudo rm -f /etc/nginx/sites-enabled/freeciv-web
+if [ ! "${NGINX_DISABLE_ON_SHUTDOW}" = "N" ]; then
+    sudo rm -f /etc/nginx/sites-enabled/freeciv-web
+fi
 
 # Shutdown Freeciv-web's dependency services according to the users
 # configuration.


### PR DESCRIPTION
Support running Freeciv-web as a user without access to sudo. An admin can
enable Freeciv-web for NGINX and give the user access to restart the
dependency services without granting the user that runs Freeciv-web root.

I run Freeciv-web under a user without sudo access. I'm tired of getting
emails warning me about how this user tried to use sudo each time I forget to
modify the scripts that starts and stops Freeciv-web.