### PR TITLE
Reenable CasperJS tests

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -75,7 +75,7 @@ else
 fi
 
 if [ "${FCW_INSTALL_MODE}" = TEST ]; then
-  dependencies="${dependencies} xvfb"
+  dependencies="${dependencies} xauth xvfb phantomjs"
 fi
 
 echo "==== Installing Updates and Dependencies ===="

--- a/scripts/install/ext-install.sh
+++ b/scripts/install/ext-install.sh
@@ -61,7 +61,7 @@ ext_install_casperjs () {
   curl -LOsS 'https://github.com/casperjs/casperjs/archive/1.1.4.zip'
   unzip -qo 1.1.4.zip
   rm 1.1.4.zip
-  sudo ln -sf "${basedir}/casperjs-1.1.4/bin/casperjs" /usr/local/bin/casperjs
+  sudo ln -sf "${basedir}/tests/casperjs-1.1.4/bin/casperjs" /usr/local/bin/casperjs
   ext_installed[${#ext_installed[@]}]="casperjs"
 }
 

--- a/scripts/install/ext-install.sh
+++ b/scripts/install/ext-install.sh
@@ -56,12 +56,13 @@ ext_install_tomcat8 () {
 }
 
 ext_install_casperjs () {
-  echo "==== Installing CasperJS for testing ===="
+  version=1.1.4-2
+  echo "==== Installing CasperJS ${version} for testing ===="
   cd "${basedir}/tests"
-  curl -LOsS 'https://github.com/casperjs/casperjs/archive/1.1.4.zip'
-  unzip -qo 1.1.4.zip
-  rm 1.1.4.zip
-  sudo ln -sf "${basedir}/tests/casperjs-1.1.4/bin/casperjs" /usr/local/bin/casperjs
+  curl -LOsS "https://github.com/casperjs/casperjs/archive/${version}.zip"
+  unzip -qo "${version}".zip
+  rm "${version}".zip
+  sudo ln -sf "${basedir}/tests/casperjs-${version}/bin/casperjs" /usr/local/bin/casperjs
   ext_installed[${#ext_installed[@]}]="casperjs"
 }
 

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -2,6 +2,17 @@
 
 # Freeciv-web Travis CI test script
 
+error=0
+
+casper_test () {
+  xvfb-run --server-args="-screen 0 800x600x24" casperjs --engine=phantomjs test "$@"
+  err=$?
+  if [ $err -ne 0 ]; then
+    >&2 echo "Freeciv-web CasperJS test $@ failed with exit code ${err}"
+    error=1
+  fi
+}
+
 basedir=$(pwd)
 
 cd ${basedir}/scripts/ && ./start-freeciv-web.sh
@@ -12,17 +23,25 @@ echo "============================================"
 echo "Start testing of Freeciv-web using CasperJS:"
 cd ${basedir}/tests/
 
-xvfb-run --server-args="-screen 0 800x600x24" casperjs --engine=phantomjs test freeciv-web-tests.js || { >&2 echo "Freeciv-web CasperJS tests failed with exit code ${?}!" && exit 1; }
+casper_test freeciv-web-tests.js
 
 echo "Running Freeciv-web server in autogame mode."
+mv "${basedir}"/publite2/pubscript_singleplayer.serv{,.bak}
 cp ${basedir}/publite2/pubscript_autogame.serv ${basedir}/publite2/pubscript_singleplayer.serv
 killall freeciv-web
 sleep 20
-xvfb-run --server-args="-screen 0 800x600x24" casperjs --engine=phantomjs test freeciv-web-autogame.js || { >&2 echo "Freeciv-web CasperJS autogame tests failed with exit code ${?}!" && exit 1; }
+casper_test freeciv-web-autogame.js
+mv "${basedir}"/publite2/pubscript_singleplayer.serv{.bak,}
 
 echo "running pbem unit tests."
 cd ${basedir}/pbem
-python3 test_pbem.py
+if ! python3 test_pbem.py; then
+  error=1
+fi
 
 #echo "=============================="
-echo "Freeciv-web built, tested and started correctly: Build successful!"
+if [ ${error} -eq 0 ]; then
+  echo "Freeciv-web built, tested and started correctly: Build successful!"
+else
+  exit 1
+fi

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -12,13 +12,13 @@ echo "============================================"
 echo "Start testing of Freeciv-web using CasperJS:"
 cd ${basedir}/tests/
 
-xvfb-run casperjs --engine=phantomjs test freeciv-web-tests.js || (>&2 echo "Freeciv-web CasperJS tests failed!" && exit 1)
+xvfb-run casperjs --engine=phantomjs test freeciv-web-tests.js || { >&2 echo "Freeciv-web CasperJS tests failed with exit code ${?}!" && exit 1; }
 
 echo "Running Freeciv-web server in autogame mode."
 cp ${basedir}/publite2/pubscript_autogame.serv ${basedir}/publite2/pubscript_singleplayer.serv
 killall freeciv-web
 sleep 20
-xvfb-run casperjs --engine=phantomjs test freeciv-web-autogame.js || (>&2 echo "Freeciv-web CasperJS autogame tests failed!" && exit 1)
+xvfb-run casperjs --engine=phantomjs test freeciv-web-autogame.js || { >&2 echo "Freeciv-web CasperJS autogame tests failed with exit code ${?}!" && exit 1; }
 
 echo "running pbem unit tests."
 cd ${basedir}/pbem

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -12,13 +12,13 @@ echo "============================================"
 echo "Start testing of Freeciv-web using CasperJS:"
 cd ${basedir}/tests/
 
-xvfb-run casperjs --engine=phantomjs test freeciv-web-tests.js || { >&2 echo "Freeciv-web CasperJS tests failed with exit code ${?}!" && exit 1; }
+xvfb-run --server-args="-screen 0 800x600x24" casperjs --engine=phantomjs test freeciv-web-tests.js || { >&2 echo "Freeciv-web CasperJS tests failed with exit code ${?}!" && exit 1; }
 
 echo "Running Freeciv-web server in autogame mode."
 cp ${basedir}/publite2/pubscript_autogame.serv ${basedir}/publite2/pubscript_singleplayer.serv
 killall freeciv-web
 sleep 20
-xvfb-run casperjs --engine=phantomjs test freeciv-web-autogame.js || { >&2 echo "Freeciv-web CasperJS autogame tests failed with exit code ${?}!" && exit 1; }
+xvfb-run --server-args="-screen 0 800x600x24" casperjs --engine=phantomjs test freeciv-web-autogame.js || { >&2 echo "Freeciv-web CasperJS autogame tests failed with exit code ${?}!" && exit 1; }
 
 echo "running pbem unit tests."
 cd ${basedir}/pbem

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -12,14 +12,13 @@ echo "============================================"
 echo "Start testing of Freeciv-web using CasperJS:"
 cd ${basedir}/tests/
 
-# FIXME! CasperJS tests are disabled, because they started failing. Will have to look into why they fail.
-#xvfb-run casperjs --engine=phantomjs test freeciv-web-tests.js || (>&2 echo "Freeciv-web CasperJS tests failed!" && exit 1)
+xvfb-run casperjs --engine=phantomjs test freeciv-web-tests.js || (>&2 echo "Freeciv-web CasperJS tests failed!" && exit 1)
 
-#echo "Running Freeciv-web server in autogame mode."
-#cp ${basedir}/publite2/pubscript_autogame.serv ${basedir}/publite2/pubscript_singleplayer.serv
-#killall freeciv-web
-#sleep 20
-#xvfb-run casperjs --engine=phantomjs test freeciv-web-autogame.js || (>&2 echo "Freeciv-web CasperJS autogame tests failed!" && exit 1)
+echo "Running Freeciv-web server in autogame mode."
+cp ${basedir}/publite2/pubscript_autogame.serv ${basedir}/publite2/pubscript_singleplayer.serv
+killall freeciv-web
+sleep 20
+xvfb-run casperjs --engine=phantomjs test freeciv-web-autogame.js || (>&2 echo "Freeciv-web CasperJS autogame tests failed!" && exit 1)
 
 echo "running pbem unit tests."
 cd ${basedir}/pbem

--- a/tests/freeciv-web-autogame.js
+++ b/tests/freeciv-web-autogame.js
@@ -26,15 +26,15 @@ casper.test.begin('Test starting new Freeciv-web autogame', 3, function suite(te
     casper.thenEvaluate(function() {
       /* Starting new game automatically from Javascript.*/
       dialog_close_trigger = "button";
-      if (validate_username()) {
-        $("#dialog").dialog('close');
-        setTimeout("send_message('/ai CasperJs');", 4000);
-        setTimeout("send_message('/start');", 4200);
-        setInterval("eval(\"console.log('Running autogame... Current turn: ' + game_info['turn'] + ' - chat messages: ' + get_chatbox_text());\");", 30000);
-      }
+      validate_username_callback();
+      setTimeout("send_message('/ai CasperJs');", 4000);
+      // City dialogs get in the way, hide messages and stop updates
+      show_city_dialog = function() {};
+      setTimeout("send_message('/start');", 4200);
+      setInterval("eval(\"console.log('Running autogame... Current turn: ' + game_info['turn'] + ' - chat messages: ' + get_chatbox_text());\");", 30000);
     });
 
-    casper.waitForText("T200", function() {
+    casper.waitForText("Game ended", function() {
       //this.clickLabel('Ok');
       this.echo("Captured screenshot to be saved as screenshot-autogame.png");
       this.capture('screenshot-autogame.png', undefined, {

--- a/tests/freeciv-web-tests.js
+++ b/tests/freeciv-web-tests.js
@@ -10,7 +10,7 @@ casper.on('remote.message', function(message) {
 });
 
 casper.test.begin('Test of Tomcat8 running on localhost port 8080.', 2, function suite(test) {
-    casper.start("http://localhost:8080/", function() {
+    casper.start("http://localhost:8080/freeciv-web/", function() {
         test.assertHttpStatus(200);
         test.assertTitleMatch(/Freeciv-web/, 'Freeciv-web title is present');
     });
@@ -99,10 +99,8 @@ casper.test.begin('Test starting new Freeciv-web game', 10, function suite(test)
     casper.thenEvaluate(function() {
       /* Starting new game automatically from Javascript.*/
       dialog_close_trigger = "button";
-      if (validate_username()) {
-        $("#dialog").dialog('close');
-        setTimeout("pregame_start_game();", 3000);
-      }
+      autostart = true;
+      validate_username_callback();
     });
 
     casper.waitForText("World map", function() {


### PR DESCRIPTION
Before merging, please consider this:
* The Travis build takes about twice as much time
* The tests are very general, they may only be useful to find if the client can start, not whether part of functionality work
* CasperJS is unmantained