### PR TITLE
Adjust server configure parameters

### DIFF
--- a/freeciv/prepare_freeciv.sh
+++ b/freeciv/prepare_freeciv.sh
@@ -32,7 +32,7 @@ cp freeciv /tmp -rf
 cp freeciv-web.project /tmp
 
 ( cd /tmp/freeciv
-  ./autogen.sh CFLAGS="-O3" --enable-mapimg=magickwand --with-project-definition=../freeciv-web.project --enable-fcweb --enable-json --disable-delta-protocol --disable-nls --disable-fcmp --enable-freeciv-manual --disable-ruledit --enable-fcdb=no --enable-ai-static=classic,threaded --prefix=${HOME}/freeciv/ && make -s -j$(nproc)
+  ./autogen.sh CFLAGS="-O3" --enable-mapimg=magickwand --with-project-definition=../freeciv-web.project --enable-fcweb --enable-json --disable-delta-protocol --disable-nls --disable-fcmp --enable-freeciv-manual --disable-ruledit --disable-ruleup --disable-fcdb --enable-ai-static=classic,tex --prefix=${HOME}/freeciv/ && make -s -j$(nproc)
 )
 
 cp -rfu /tmp/freeciv .  || echo "done"


### PR DESCRIPTION
Add --disable-ruleup.
Option became available with the latest server update

Turn --enable-fcdb=no to --disable-fcdb
Just for consistency

Replace AI module threaded with tex
Neither is really usable, but threaded is fundamentally broken
and has no hope of ever getting fixed, while tex is in development.

Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>