### PR TITLE
Clean out more server compiler warnings

### DIFF
--- a/freeciv/apply_patches.sh
+++ b/freeciv/apply_patches.sh
@@ -32,6 +32,10 @@
 #     It was committed as 7a57cea0673432472946956d9f8c635e9f165da2
 # 0025-Do-end_phase-research-updates-for-alive-players-only.patch is hrm Bug #873692
 #     It was committed as 833d1fb14c3a5014bc4eeccfe652f5d9dddf3119
+# 0009-Fix-cvercmp-compiler-warning-with-gcc-10-and-O3.patch is hrm Bug #886330
+#     It was committed as 7527315835c16179e68080fe8f7244c76152b656
+# 0010-Fix-stdinhand.c-compiler-warning-with-gcc-10-and-O3.patch is hrm Bug #886331
+#     It was committed as 71eb308f799fd62920077d68d9109448d47cc7a8
 
 # Not in the upstream Freeciv server
 # ----------------------------------
@@ -55,6 +59,12 @@
 # endgame-mapimg is used to generate a mapimg at endgame for hall of fame.
 
 declare -a PATCHLIST=(
+  "0003-Switch-from-python-to-python3"
+  "0009-Fix-cvercmp-compiler-warning-with-gcc-10-and-O3"
+  "0001-Terminate-format-escapes-list"
+  "0024-mapimg_colortest-Fix-compiler-warning-with-O3"
+  "0001-Refactor-code-to-avoid-gcc-10-warning"
+  "0010-Fix-stdinhand.c-compiler-warning-with-gcc-10-and-O3"
   "city_impr_fix2"
   "city-naming-change"
   "metachange"
@@ -84,16 +94,12 @@ declare -a PATCHLIST=(
   "webgl_vision_cheat_temporary"
   "endgame-mapimg"
   "0001-Fix-segfault-at-loading-older-format-savegame"
-  "0003-Switch-from-python-to-python3"
   "0015-savegame3.c-Remove-aifill-players-after-rulesets-loa"
-  "0001-Terminate-format-escapes-list"
-  "0001-Refactor-code-to-avoid-gcc-10-warning"
   "0023-Fix-sell_random_unit-crash-with-recursive-transports"
   "0005-Fix-ghost-unit-issue-when-unit-is-loaded-to-an-trans"
   "0001-Fix-clang-9-warnings"
   "0001-Fix-division-by-zero-when-transforming-unit-with-zer"
   "0006-debug.m4-Set-always-active-compiler-flags-last-not-f"
-  "0024-mapimg_colortest-Fix-compiler-warning-with-O3"
   "0001-Set-player-tile-owner-whenever-tile-knowledge-is-upd"
   "0025-Do-end_phase-research-updates-for-alive-players-only"
 )

--- a/freeciv/patches/0009-Fix-cvercmp-compiler-warning-with-gcc-10-and-O3.patch
+++ b/freeciv/patches/0009-Fix-cvercmp-compiler-warning-with-gcc-10-and-O3.patch
@@ -1,0 +1,30 @@
+From c2cd11acab33bc54028bceb94e784031eb0f5f82 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Sat, 5 Sep 2020 14:12:59 +0300
+Subject: [PATCH 9/9] Fix cvercmp compiler warning with gcc-10 and -O3
+
+See hrm Bug #886330
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ dependencies/cvercmp/cvercmp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/dependencies/cvercmp/cvercmp.c b/dependencies/cvercmp/cvercmp.c
+index b2c596da77..f2d5d6912a 100644
+--- a/dependencies/cvercmp/cvercmp.c
++++ b/dependencies/cvercmp/cvercmp.c
+@@ -286,7 +286,9 @@ static char **cvercmp_ver_subtokenize(const char *ver)
+   for (i = 0, idx = 0; i < num; i++) {
+     tokenlen = cvercmp_next_subtoken(ver + idx);
+     tokens[i] = malloc(sizeof(char) * (tokenlen + 1));
+-    strncpy(tokens[i], ver + idx, tokenlen);
++    if (tokenlen > 0) {
++      strncpy(tokens[i], ver + idx, tokenlen);
++    }
+     tokens[i][tokenlen] = '\0';
+     idx += tokenlen;
+   }
+-- 
+2.28.0
+

--- a/freeciv/patches/0010-Fix-stdinhand.c-compiler-warning-with-gcc-10-and-O3.patch
+++ b/freeciv/patches/0010-Fix-stdinhand.c-compiler-warning-with-gcc-10-and-O3.patch
@@ -1,0 +1,36 @@
+From 12e5759ea157729422cda79c501a4297ccea939e Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Sat, 5 Sep 2020 14:41:02 +0300
+Subject: [PATCH 10/10] Fix stdinhand.c compiler warning with gcc-10 and -O3
+
+See hrm Bug #886331
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ server/stdinhand.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/server/stdinhand.c b/server/stdinhand.c
+index 59f0b8897f..1f325ea424 100644
+--- a/server/stdinhand.c
++++ b/server/stdinhand.c
+@@ -1421,8 +1421,14 @@ static bool cmdlevel_command(struct connection *caller, char *str, bool check)
+               _("Command access levels in effect:"));
+     cmd_reply(CMD_CMDLEVEL, caller, C_COMMENT, horiz_line);
+     conn_list_iterate(game.est_connections, pconn) {
+-      cmd_reply(CMD_CMDLEVEL, caller, C_COMMENT, "cmdlevel %s %s",
+-                cmdlevel_name(conn_get_access(pconn)), pconn->username);
++      const char *lvl_name = cmdlevel_name(conn_get_access(pconn));
++
++      if (lvl_name != NULL) {
++        cmd_reply(CMD_CMDLEVEL, caller, C_COMMENT, "cmdlevel %s %s",
++                  lvl_name, pconn->username);
++      } else {
++        fc_assert(lvl_name != NULL); /* Always fails when reached. */
++      }
+     } conn_list_iterate_end;
+     cmd_reply(CMD_CMDLEVEL, caller, C_COMMENT,
+               _("Command access level for new connections: %s"),
+-- 
+2.28.0
+


### PR DESCRIPTION
Backport a couple more compiler warning fixes.
Apply these patches first, so they are in effect when working
on later patches of partly applied stack.

Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>