### PR TITLE
Dockerfile: Fix container building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ COPY LICENSE.txt /docker/LICENSE.txt
 COPY requirements.txt /docker/requirements.txt
 
 COPY scripts /docker/scripts
-COPY tests /docker/tests
 COPY music /docker/music
 COPY blender /docker/blender
 COPY nginx /docker/nginx


### PR DESCRIPTION
Don't try to copy 'tests' directory, removed recently, to the container.

Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>