### PR TITLE
Factor out action_decision_clear_want().

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -756,6 +756,26 @@ function action_selection_no_longer_in_progress(old_actor_id)
   is_more_user_input_needed = false;
 }
 
+/**********************************************************************//**
+  Have the server record that a decision no longer is wanted for the
+  specified unit.
+**************************************************************************/
+function action_decision_clear_want(old_actor_id)
+{
+  var old = game_find_unit_by_number(old_actor_id);
+
+  if (old !== null) {
+    /* Have the server record that a decision no longer is wanted. */
+    var unqueue = {
+      "pid"     : packet_unit_sscs_set,
+      "unit_id" : old_actor_id,
+      "type"    : USSDT_UNQUEUE,
+      "value"   : IDENTITY_NUMBER_ZERO
+    };
+    send_request(JSON.stringify(unqueue));
+  }
+}
+
 /****************************************************************************
   Return TRUE iff a unit on this tile is in focus.
 ****************************************************************************/

--- a/freeciv-web/src/main/webapp/javascript/packhand.js
+++ b/freeciv-web/src/main/webapp/javascript/packhand.js
@@ -965,13 +965,7 @@ function handle_unit_actions(packet)
      * selection dialog to be answered before requesting data for the next
      * one. This lack of a queue allows it to be cleared here. */
 
-    var unqueue = {
-      "pid"     : packet_unit_sscs_set,
-      "unit_id" : actor_unit_id,
-      "type"    : USSDT_UNQUEUE,
-      "value"   : IDENTITY_NUMBER_ZERO
-    };
-    send_request(JSON.stringify(unqueue));
+    action_decision_clear_want(actor_unit_id);
   }
 
   if (hasActions && disturb_player) {


### PR DESCRIPTION
The function action_decision_clear_want() will be needed to implement an action selection dialog follows the unit focus queue system like the C clients have had since Freeciv 2.6.