### PR TITLE
Backport gcc-11, autoconf-2.70 warning fixes

### DIFF
--- a/freeciv/apply_patches.sh
+++ b/freeciv/apply_patches.sh
@@ -20,6 +20,18 @@
 #     It was committed as 7527315835c16179e68080fe8f7244c76152b656
 # 0010-Fix-stdinhand.c-compiler-warning-with-gcc-10-and-O3.patch is hrm Bug #886331
 #     It was committed as 71eb308f799fd62920077d68d9109448d47cc7a8
+# 0008-configure.ac-Drop-use-of-obsolete-AC_HEADER_TIME.patch
+#     is hrm Feature #889543.
+#     It was committed as 20b75101a6d7e98eef27fc49dd2304e6262cc584
+# 0009-configure.ac-Drop-use-of-obsolete-AC_HEADER_STDC.patch
+#     is hrm Feature #889544
+#     It was committed as 54267cb9596570dad2aef2db720789d80b8c6cf7
+# 0025-Don-t-hide-allied-stealth-units-on-seen-tiles.patch
+#     is hrm Bug #764976
+#     It was committed as 9fd4cd5397c25f99a4cba4fc27700d54bf087898
+# 0005-Fix-gcc-11-stringop-overread-error-at-comparing-scen.patch
+#     is hrm Bug #894423
+#     It was committed as f34a882ddf9f7065acb39628fc6cb5b2cf2975dd
 # 0001-Make-generated-random-seed-less-predictable.patch is hrm Bug #914184
 #     It was committed as a56144bd28e2a19707cee5c5c3028a12c634d0ff
 
@@ -48,6 +60,10 @@ declare -a PATCHLIST=(
   "0009-Fix-cvercmp-compiler-warning-with-gcc-10-and-O3"
   "0024-mapimg_colortest-Fix-compiler-warning-with-O3"
   "0010-Fix-stdinhand.c-compiler-warning-with-gcc-10-and-O3"
+  "0008-configure.ac-Drop-use-of-obsolete-AC_HEADER_TIME"
+  "0009-configure.ac-Drop-use-of-obsolete-AC_HEADER_STDC"
+  "0025-Don-t-hide-allied-stealth-units-on-seen-tiles"
+  "0005-Fix-gcc-11-stringop-overread-error-at-comparing-scen"
   "0001-Make-generated-random-seed-less-predictable"
   "city_impr_fix2"
   "city-naming-change"

--- a/freeciv/patches/0005-Fix-gcc-11-stringop-overread-error-at-comparing-scen.patch
+++ b/freeciv/patches/0005-Fix-gcc-11-stringop-overread-error-at-comparing-scen.patch
@@ -1,0 +1,33 @@
+From b6aa51e0722557721a9b474eb75aceeaec4f5f86 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Sun, 8 Nov 2020 15:45:42 +0200
+Subject: [PATCH 05/10] Fix gcc-11 stringop-overread error at comparing
+ scenario.authors fields
+
+See hrm Bug #894423
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ server/edithand.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/server/edithand.c b/server/edithand.c
+index eb8eb0cdb8..973cf6d54c 100644
+--- a/server/edithand.c
++++ b/server/edithand.c
+@@ -1428,8 +1428,11 @@ void handle_edit_game(struct connection *pc,
+     changed = TRUE;
+   }
+ 
++  FC_STATIC_ASSERT(sizeof(packet->scenario_authors) == sizeof(game.scenario.authors),
++                   scen_authors_field_size_mismatch);
++
+   if (0 != strncmp(packet->scenario_authors, game.scenario.authors,
+-                   MAX_LEN_PACKET)) {
++                   sizeof(game.scenario.authors))) {
+     sz_strlcpy(game.scenario.authors, packet->scenario_authors);
+     changed = TRUE;
+   }
+-- 
+2.28.0
+

--- a/freeciv/patches/0008-configure.ac-Drop-use-of-obsolete-AC_HEADER_TIME.patch
+++ b/freeciv/patches/0008-configure.ac-Drop-use-of-obsolete-AC_HEADER_TIME.patch
@@ -1,0 +1,30 @@
+From 9ccec4f35b4114944e1cd5b598f22011492545d6 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Wed, 30 Sep 2020 11:12:19 +0300
+Subject: [PATCH 8/9] configure.ac: Drop use of obsolete AC_HEADER_TIME
+
+Autoconf-2.70 was giving a warning about it. We didn't use its
+results anyway (with any version of autoconf).
+
+See hrm Feature #889543
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ configure.ac | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index b86233d224..c528cd36c1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1261,7 +1261,6 @@ fi
+ 
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+-AC_HEADER_TIME
+ AC_STRUCT_TM
+ AC_CHECK_TYPES([socklen_t], [AC_DEFINE([FREECIV_HAVE_SOCKLEN_T], [1], [Have socklen_t type defined])],
+ [],
+-- 
+2.28.0
+

--- a/freeciv/patches/0009-configure.ac-Drop-use-of-obsolete-AC_HEADER_STDC.patch
+++ b/freeciv/patches/0009-configure.ac-Drop-use-of-obsolete-AC_HEADER_STDC.patch
@@ -1,0 +1,30 @@
+From 6dc92a168d44608bea7ede94de7ee7124c22a866 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Wed, 30 Sep 2020 11:28:35 +0300
+Subject: [PATCH 9/9] configure.ac: Drop use of obsolete AC_HEADER_STDC
+
+Autoconf-2.70 was giving a warning about it. We didn't use its
+results anyway (with any version of autoconf).
+
+See hrm Feature #889544
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ configure.ac | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index c528cd36c1..7b12d9c454 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1225,7 +1225,6 @@ fi
+ AC_CHECK_LIB(nls,main)
+ 
+ dnl Checks for header files.
+-AC_HEADER_STDC
+ AC_HEADER_SYS_WAIT
+ AC_CHECK_HEADERS([fcntl.h sys/utsname.h \
+                   sys/file.h signal.h strings.h execinfo.h \
+-- 
+2.28.0
+

--- a/freeciv/patches/0025-Don-t-hide-allied-stealth-units-on-seen-tiles.patch
+++ b/freeciv/patches/0025-Don-t-hide-allied-stealth-units-on-seen-tiles.patch
@@ -1,0 +1,70 @@
+From 4c898b6a9d7296bee0df4666676152c67ec7dfe9 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Mon, 19 Oct 2020 10:34:08 +0300
+Subject: [PATCH 25/25] Don't hide allied stealth units on seen tiles
+
+They are expected to be visible. Hiding them lead to duplicate
+unit removal from client when such a unit dies
+
+Reported by Jacob Nevins
+
+See hrm Bug #764976
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ common/player.c  | 5 ++---
+ server/maphand.c | 8 ++++++--
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/common/player.c b/common/player.c
+index d779c1ecf4..d181e6d016 100644
+--- a/common/player.c
++++ b/common/player.c
+@@ -1028,7 +1028,8 @@ bool can_player_see_unit_at(const struct player *pplayer,
+     } extra_type_list_iterate_end;
+   }
+ 
+-  /* Allied or non-hiding units are always seen. */
++  /* Allied or non-hiding units are always seen.
++   * See also stealth unit hiding part in map_change_seen() */
+   if (pplayers_allied(unit_owner(punit), pplayer)
+       || !is_hiding_unit(punit)) {
+     return TRUE;
+@@ -1037,8 +1038,6 @@ bool can_player_see_unit_at(const struct player *pplayer,
+   /* Hiding units are only seen by the V_INVIS fog layer. */
+   return fc_funcs->player_tile_vision_get(ptile, pplayer,
+                                           unit_type_get(punit)->vlayer);
+-
+-  return FALSE;
+ }
+ 
+ /*******************************************************************//**
+diff --git a/server/maphand.c b/server/maphand.c
+index 78bbc2fa4e..631300c1dc 100644
+--- a/server/maphand.c
++++ b/server/maphand.c
+@@ -601,7 +601,7 @@ void send_tile_info(struct conn_list *dest, struct tile *ptile,
+   Assumption: Each unit type is visible on only one layer.
+ **************************************************************************/
+ static bool unit_is_visible_on_layer(const struct unit *punit,
+-				     enum vision_layer vlayer)
++                                     enum vision_layer vlayer)
+ {
+   return XOR(vlayer == V_MAIN, is_hiding_unit(punit));
+ }
+@@ -916,7 +916,11 @@ void map_change_seen(struct player *pplayer,
+ 
+     unit_list_iterate(ptile->units, punit) {
+       if (unit_is_visible_on_layer(punit, V_INVIS)
+-          && can_player_see_unit(pplayer, punit)) {
++          && can_player_see_unit(pplayer, punit)
++          && (plrtile->seen_count[V_MAIN] + change[V_MAIN] <= 0
++              || !pplayers_allied(pplayer, unit_owner(punit)))) {
++        /* Allied units on seen tiles (V_MAIN) are always seen.
++         * That's how can_player_see_unit_at() works. */
+         unit_goes_out_of_sight(pplayer, punit);
+       }
+     } unit_list_iterate_end;
+-- 
+2.28.0
+


### PR DESCRIPTION
Backport couple of patches, mainly fixing warnings from newer
build tools.