### PR TITLE
Factor out ask_server_for_actions()

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/action_dialog.js
+++ b/freeciv-web/src/main/webapp/javascript/action_dialog.js
@@ -468,7 +468,6 @@ function popup_action_selection(actor_unit, action_probabilities,
       buttons: buttons });
 
   $(id).dialog('open');
-  action_selection_in_progress_for = actor_unit['id'];
   is_more_user_input_needed = false;
 }
 

--- a/freeciv-web/src/main/webapp/javascript/packhand.js
+++ b/freeciv-web/src/main/webapp/javascript/packhand.js
@@ -921,7 +921,7 @@ function unit_actor_wants_input(pdiplomat)
     return;
   }
 
-  process_diplomat_arrival(pdiplomat, pdiplomat['action_decision_tile']);
+  ask_server_for_actions(pdiplomat);
 }
 
 /**************************************************************************


### PR DESCRIPTION
The function ask_server_for_actions() will be needed to implement an
action selection dialog follows the unit focus queue system like the C
clients have had since Freeciv 2.6.