### PR TITLE
Unit action decision wanted marker

### DIFF
--- a/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
+++ b/freeciv-web/src/main/webapp/javascript/2dcanvas/tilespec.js
@@ -629,6 +629,14 @@ function fill_unit_sprite_array(punit, stacked, backdrop)
     result.push(activities);
   }
 
+  if (should_ask_server_for_actions(punit)) {
+    result.push({
+      "key"      : "unit.action_decision_want",
+      "offset_x" : unit_activity_offset_x + unit_offset['x'],
+      "offset_y" : -unit_activity_offset_y + unit_offset['y'],
+    });
+  }
+
   result.push(get_unit_hp_sprite(punit));
   if (stacked) result.push(get_unit_stack_sprite());
   if (punit['veteran'] > 0) result.push(get_unit_veteran_sprite(punit));

--- a/freeciv-web/src/main/webapp/javascript/control.js
+++ b/freeciv-web/src/main/webapp/javascript/control.js
@@ -742,6 +742,19 @@ function check_text_input(event,chatboxtextarea) {
 
 
 /**********************************************************************//**
+  Returns TRUE iff the client should ask the server about what actions a
+  unit can perform.
+**************************************************************************/
+function should_ask_server_for_actions(punit)
+{
+  return (punit['action_decision_want'] === ACT_DEC_ACTIVE
+          /* The player is interested in getting a pop up for a mere
+           * arrival. */
+          || (punit['action_decision_want'] === ACT_DEC_PASSIVE
+              && popup_actor_arrival));
+}
+
+/**********************************************************************//**
   Ask the server about what actions punit may be able to perform against
   it's stored target tile.
 


### PR DESCRIPTION
Use "unit.action_decision_want" to mark that a unit wants an action decision
if it is defined. The symbol is only shown for passive action decisions if
the client configuration has set popup_actor_arrival.

Like gna patch #7049 for the C clients.