### PR TITLE
Update to Freeciv server freeciv/freeciv@5c64320446

### DIFF
--- a/freeciv/version.txt
+++ b/freeciv/version.txt
@@ -1,7 +1,7 @@
 # The Git SHA hash for the commit to checkout from
 # https://github.com/freeciv/freeciv
 
-FCREV=4add33c249a81bb4d20494d8cce8ec006d7e0ce0
+FCREV=5c64320446348752a681486ae4841966ef2b9efb
 
 ORIGCAPSTR="+Freeciv.Devel-3.2-2021.Mar.31"
 


### PR DESCRIPTION
Freeciv commit message:
Success dice roll for "Poison City [Escape]".

Make it possible to add a pre action dice throw to "Poison City" and to
"Poison City Escape".

Given higher priority after a discussion with Lexxie L and Marko Lindqvist
around a year ago.

See hrm Feature #869738