### PR TITLE
Update list of known servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Freeciv-web is an open-source turn-based strategy game. It can be played in any 
 Freeciv-web is free and open source software. The Freeciv C server is released under the GNU General Public License, while the Freeciv-web client is released
 under the GNU Affero General Public License. See [License](LICENSE.txt) for the full license document.
 
-Currently known servers based on Freeciv-web:
-- [freecivweb.org](https://www.freecivweb.org) [https://github.com/Lexxie9952/fcw.org-server]
+Currently known servers based on Freeciv-web, which are open source in compliance with the AGPL license:
 - [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
 
 Freeciv WebGL 3D:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ under the GNU Affero General Public License. See [License](LICENSE.txt) for the 
 
 Live servers
 ------------
-Currently known servers based on Freeciv-web, which are open source in compliance with the [https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt](AGPL license):
+Currently known servers based on Freeciv-web, which are open source in compliance with [the AGPL license](https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt):
 - [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
 
 Freeciv WebGL 3D:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Live servers
 Currently known servers based on Freeciv-web, which are open source in compliance with [the AGPL license](https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt):
 - [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
 
+Freeciv-web screenshots:
+------------------------
 Freeciv WebGL 3D:
 ![Freeciv-web](https://raw.githubusercontent.com/freeciv/freeciv-web/develop/freeciv-web/src/main/webapp/javascript/webgl/freeciv-webgl.png "Freeciv-web WebGL screenshot")
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Freeciv-web is an open-source turn-based strategy game. It can be played in any 
 Freeciv-web is free and open source software. The Freeciv C server is released under the GNU General Public License, while the Freeciv-web client is released
 under the GNU Affero General Public License. See [License](LICENSE.txt) for the full license document.
 
-Currently known servers based on Freeciv-web, which are open source in compliance with the AGPL license:
+
+Live servers
+------------
+Currently known servers based on Freeciv-web, which are open source in compliance with the [https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt](AGPL license):
 - [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
 
 Freeciv WebGL 3D:


### PR DESCRIPTION
- Freecivweb.org currently has a [cease and desist issue](https://github.com/Lexxie9952/fcw.org-server/issues/168) because of an AGPL license violation. Freecivweb.org is currently not publishing the source code in compliance with the AGPL license. The source code of the version running on the live server is published on a private server. Therefore Freecivweb.org will be removed from the list of known servers.