### PR TITLE
adding Tactics & Triumph to site list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ under the GNU Affero General Public License. See [License](LICENSE.txt) for the 
 Live servers
 ------------
 Currently known servers based on Freeciv-web, which are open source in compliance with [the AGPL license](https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt):
+- [Freeciv Tactics & Triumph](https://www.tacticsandtriumph.com)  [https://github.com/Canik05/freeciv-tnt] Freeciv Games & Mods (No PBEM)
 - [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
 
 Freeciv-web screenshots:


### PR DESCRIPTION
Freeciv TnT is an AGPL compliant Freeciv variant loading commits to https://github.com/Canik05/freeciv-tnt matching the current state of https://www.tacticsandtriumph.com. 
It can be accessed via a 'Source' link prominently placed in the header links.

Freeciv TnT has been operating about 4 months and intends to continue hosting games and adding to Freeciv development for years to come. I hope you will consider adding us to the list. If you have any questions please feel free to ask. Thank you.