### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ under the GNU Affero General Public License. See [License](LICENSE.txt) for the 
 Live servers
 ------------
 Currently known servers based on Freeciv-web, which are open source in compliance with [the AGPL license](https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt):
-- [Freeciv Tactics & Triumph](https://www.tacticsandtriumph.com)  [https://github.com/Canik05/freeciv-tnt] Freeciv Games & Mods (No PBEM)
-- [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
 - [freecivweb.org](https://www.freecivweb.org) [https://github.com/Lexxie9952/fcw.org-server]
+- [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
+- [Freeciv Tactics & Triumph](https://www.tacticsandtriumph.com)  [https://github.com/Canik05/freeciv-tnt] Freeciv Games & Mods (No PBEM)
 
 Freeciv-web screenshots:
 ------------------------


### PR DESCRIPTION
1. previous commit mistakenly did not restore/respect the original list order,
which:
a. respects chronology/length of operation
b. first site on list should have the ability to play all the official bundled Freeciv rulesets