### PR TITLE
Drop libbz2-dev from the list of packages to install

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -23,7 +23,6 @@ dependencies="\
   git \
   gnupg \
   imagemagick \
-  libbz2-dev \
   libcurl4-openssl-dev \
   libicu-dev \
   libjansson-dev \


### PR DESCRIPTION
Freeciv's support for bz2 compressed savegames has dropped to the
level where new savegames cannot be created with it at all. As there
is no old savegames for freeciv/freeciv-web, bz2 support is not needed
at all.