### PR TITLE
Add python3-dev dependency

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -43,6 +43,7 @@ dependencies="\
   python3-minimal \
   python3-pip \
   python3-setuptools \
+  python3-dev \
   python3-wheel \
   sed \
   tar \


### PR DESCRIPTION
Add python3-dev dependency. This solves a problem reported by some users building Freeciv-web on docker.