### PR TITLE
Use InnoDB for all database tables to prevent locking

### DIFF
--- a/freeciv-web/src/main/resources/db/migration/V1_0__create_database.sql
+++ b/freeciv-web/src/main/resources/db/migration/V1_0__create_database.sql
@@ -30,7 +30,7 @@ CREATE TABLE `auth` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   UNIQUE KEY `email` (`email`)
-) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -49,7 +49,7 @@ CREATE TABLE `players` (
   `host` varchar(255) DEFAULT 'unknown',
   `flag` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`hostport`,`name`)
-) ENGINE=MEMORY DEFAULT CHARSET=latin1 MAX_ROWS=8192;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 MAX_ROWS=8192;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -64,7 +64,7 @@ CREATE TABLE `savegames` (
   `title` varchar(64) NOT NULL,
   `digest` varchar(256) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=30 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -89,7 +89,7 @@ CREATE TABLE `servers` (
   `available` int(11) DEFAULT '0',
   `serverid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`host`,`port`)
-) ENGINE=MEMORY DEFAULT CHARSET=latin1 MAX_ROWS=256;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 MAX_ROWS=256;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -103,7 +103,7 @@ CREATE TABLE `variables` (
   `name` varchar(64) NOT NULL DEFAULT '',
   `value` varchar(64) DEFAULT NULL,
   PRIMARY KEY (`hostport`,`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -342,6 +342,7 @@ You may want to personalize some things before starting it:
 - Users for tomcat-admin web interface.
 - Point /etc/nginx/snippets/freeciv-web-ssl.conf to your certificate and key,
   or remove SSL support from /etc/nginx/sites-available/freeciv-web.
+- Move MySQL db driver from freeciv-web webapp lib directory to Tomcat libs directory.
 
 Then run scripts/start-freeciv-web.sh and enjoy!
 EOF


### PR DESCRIPTION
Use InnoDB for all database tables to prevent locking. Document need to move MySQL driver to Tomcat libs directory.