### PR TITLE
publite: Always set the ruleset with --ruleset

### DIFF
--- a/publite2/init-freeciv-web.sh
+++ b/publite2/init-freeciv-web.sh
@@ -34,6 +34,10 @@ fi
 
 if [ -f "${6}.ruleset" ] ; then
   addArgs --ruleset $(cat "${6}.ruleset")
+else
+  # This exist for preventing user from changing the ruleset
+  # TODO: Remove once we can allow changing ruleset
+  addArgs --ruleset classic
 fi
 
 savesdir=${1}


### PR DESCRIPTION
Step to make freeciv-web's server modification redundant (less diff to upstream server)