### PR TITLE
Server: Backport fixes relevant for freeciv-web

### DIFF
--- a/freeciv/apply_patches.sh
+++ b/freeciv/apply_patches.sh
@@ -49,9 +49,18 @@
 # 0004-Fix-memory-leaks-from-req_to_fstring-usage.patch
 #   Memory leak fix
 #   osdn #45544
+# 0028-req_copy-Copy-present.patch
+#   Fix to barbarian unit requirement check depending on uninialized data
+#   osdn #45709
 # 0038-Fix-city_add_improvement_with_gov_notice-memory-leak.patch
 #   Memory leak fix
 #   osdn #45707
+# 0038-Fix-barbarians-exception-to-unit-tech-requirements.patch
+#   Fix to final issue preventing barbarians from building units
+#   osdn #45571
+# 0037-Server-CMA-Try-with-default-parameters-after-cancell.patch
+#   Improve server side CMA
+#   osdn #45727
 
 # Not in the upstream Freeciv server
 # ----------------------------------
@@ -92,7 +101,10 @@ declare -a PATCHLIST=(
   "0052-Fix-how-tech-requirement-exceptions-work-wrt-barbari"
   "0044-Add-server-support-for-web-client-to-request-CMA"
   "0004-Fix-memory-leaks-from-req_to_fstring-usage"
+  "0028-req_copy-Copy-present"
   "0038-Fix-city_add_improvement_with_gov_notice-memory-leak"
+  "0038-Fix-barbarians-exception-to-unit-tech-requirements"
+  "0037-Server-CMA-Try-with-default-parameters-after-cancell"
   "tech_req-None-detection"
   "meson_webperimental"
   "city_impr_fix2"

--- a/freeciv/patches/0028-req_copy-Copy-present.patch
+++ b/freeciv/patches/0028-req_copy-Copy-present.patch
@@ -1,0 +1,30 @@
+From be3630f44ac211a3d88b5bd5974fd14ea5088034 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Sat, 24 Sep 2022 22:53:35 +0300
+Subject: [PATCH 28/41] req_copy(): Copy "present"
+
+This was causing barbarian unit build requirement results
+to flip occasionally due to use of uninitialized "present" value.
+
+See osdn #45709
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ common/requirements.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/common/requirements.c b/common/requirements.c
+index 0e1f2dce2f..a9de864423 100644
+--- a/common/requirements.c
++++ b/common/requirements.c
+@@ -1185,6 +1185,7 @@ void req_copy(struct requirement *dst, const struct requirement *src)
+   universal_copy(&(dst->source), &(src->source));
+   dst->range = src->range;
+   dst->survives = src->survives;
++  dst->present = src->present;
+   dst->quiet = src->quiet;
+ }
+ 
+-- 
+2.35.1
+

--- a/freeciv/patches/0037-Server-CMA-Try-with-default-parameters-after-cancell.patch
+++ b/freeciv/patches/0037-Server-CMA-Try-with-default-parameters-after-cancell.patch
@@ -1,0 +1,54 @@
+From 70deb72184e0dd4df3ef1c65cd715baceb3e2f84 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Mon, 26 Sep 2022 02:31:48 +0300
+Subject: [PATCH 37/41] Server CMA: Try with default parameters after
+ cancelling user's
+
+It used to go directly to fallback where it adjusted
+current parameter - which was still user provided one
+at that point.
+
+With this change, after user's parameter fails
+- First it tries with the default parameter
+- If that too fails, then it tries with parameters
+  adjusted from the default one
+
+See osdn #45727
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ server/cityturn.c | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/server/cityturn.c b/server/cityturn.c
+index 94d5be36e5..065d53861b 100644
+--- a/server/cityturn.c
++++ b/server/cityturn.c
+@@ -409,12 +409,19 @@ void auto_arrange_workers(struct city *pcity)
+                     _("The citizen governor can't fulfill the requirements "
+                      "for %s. Passing back control."),
+                     city_link(pcity));
++
++      /* Switch to default parameters, and try with them */
++      set_default_city_manager(&cmp, pcity);
++      cm_query_result(pcity, &cmp, cmr, FALSE);
++    }
++
++    if (!cmr->found_a_valid) {
++      /* Drop surpluses and try again. */
++      cmp.minimal_surplus[O_FOOD] = 0;
++      cmp.minimal_surplus[O_SHIELD] = 0;
++      cmp.minimal_surplus[O_GOLD] = -FC_INFINITY;
++      cm_query_result(pcity, &cmp, cmr, FALSE);
+     }
+-    /* Drop surpluses and try again. */
+-    cmp.minimal_surplus[O_FOOD] = 0;
+-    cmp.minimal_surplus[O_SHIELD] = 0;
+-    cmp.minimal_surplus[O_GOLD] = -FC_INFINITY;
+-    cm_query_result(pcity, &cmp, cmr, FALSE);
+   }
+   if (!cmr->found_a_valid) {
+     /* Emergency management.  Get _some_ result.  This doesn't use
+-- 
+2.35.1
+

--- a/freeciv/patches/0038-Fix-barbarians-exception-to-unit-tech-requirements.patch
+++ b/freeciv/patches/0038-Fix-barbarians-exception-to-unit-tech-requirements.patch
@@ -1,0 +1,114 @@
+From 4a2a082c9fd0b9783ab5c0397d893823de423474 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Mon, 26 Sep 2022 05:21:53 +0300
+Subject: [PATCH 38/41] Fix barbarians' exception to unit tech requirements
+
+- Introduce are_reqs_active_ranges()
+- Call are_reqs_active_ranges() only for ranges not already
+  checked by the player level check, when checking if the
+  specific city can build a unit
+
+This means:
+
+- City level check does not override barbarians' exception
+  player range tech requirements
+- Counts as an optimization as the player and higher range
+  requirements are not checked twice
+
+See osdn #45571
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ common/city.c         | 23 ++++++++++++++---------
+ common/requirements.c | 23 +++++++++++++++++++++++
+ common/requirements.h |  6 ++++++
+ 3 files changed, 43 insertions(+), 9 deletions(-)
+
+diff --git a/common/city.c b/common/city.c
+index 094014944e..3ba7d379a2 100644
+--- a/common/city.c
++++ b/common/city.c
+@@ -897,15 +897,20 @@ bool can_city_build_unit_direct(const struct city *pcity,
+     return FALSE;
+   }
+ 
+-  /* Check unit build requirements. */
+-  if (!are_reqs_active(&(const struct req_context) {
+-                         .player = city_owner(pcity),
+-                         .city = pcity,
+-                         .tile = city_tile(pcity),
+-                         .unittype = punittype,
+-                       },
+-                       NULL,
+-                       &punittype->build_reqs, RPT_CERTAIN)) {
++  /* Check unit build requirements.
++   * Above player level check already checked anything with range >= REQ_RANGE_PLAYER.
++   * Don't recheck those. Not only for optimization, but also not to override the
++   * special handling of tech requirements for barbarians */
++  if (!are_reqs_active_ranges(0, /* The lowest range; REQ_RANGE_LOCAL */
++                              REQ_RANGE_PLAYER - 1,
++                              &(const struct req_context) {
++                                .player = city_owner(pcity),
++                                .city = pcity,
++                                .tile = city_tile(pcity),
++                                .unittype = punittype,
++                              },
++                              NULL,
++                              &punittype->build_reqs, RPT_CERTAIN)) {
+     return FALSE;
+   }
+ 
+diff --git a/common/requirements.c b/common/requirements.c
+index a9de864423..44741fce5c 100644
+--- a/common/requirements.c
++++ b/common/requirements.c
+@@ -3919,6 +3919,29 @@ bool are_reqs_active(const struct req_context *context,
+       return FALSE;
+     }
+   } requirement_vector_iterate_end;
++
++  return TRUE;
++}
++
++/**********************************************************************//**
++  Like are_reqs_active() but checks only requirements that have
++  one of the ranges between min_range and max_range.
++**************************************************************************/
++bool are_reqs_active_ranges(const enum req_range min_range,
++                            const enum req_range max_range,
++                            const struct req_context *context,
++                            const struct player *other_player,
++                            const struct requirement_vector *reqs,
++                            const enum   req_problem_type prob_type)
++{
++  requirement_vector_iterate(reqs, preq) {
++    if (preq->range >= min_range && preq->range <= max_range) {
++      if (!is_req_active(context, other_player, preq, prob_type)) {
++        return FALSE;
++      }
++    }
++  } requirement_vector_iterate_end;
++
+   return TRUE;
+ }
+ 
+diff --git a/common/requirements.h b/common/requirements.h
+index 9e98c15829..068756dcb5 100644
+--- a/common/requirements.h
++++ b/common/requirements.h
+@@ -146,6 +146,12 @@ bool are_reqs_active(const struct req_context *context,
+                      const struct player *other_player,
+                      const struct requirement_vector *reqs,
+                      const enum   req_problem_type prob_type);
++bool are_reqs_active_ranges(const enum req_range min_range,
++                            const enum req_range max_range,
++                            const struct req_context *context,
++                            const struct player *other_player,
++                            const struct requirement_vector *reqs,
++                            const enum   req_problem_type prob_type);
+ 
+ bool is_req_unchanging(const struct requirement *req);
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
- 0028-req_copy-Copy-present.patch
- 0037-Server-CMA-Try-with-default-parameters-after-cancell.patch
- 0038-Fix-barbarians-exception-to-unit-tech-requirements.patch