### PR TITLE
Install at least version 0.60.3 of meson

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -112,7 +112,7 @@ fi
 # Populate ~/.config with current user
 npm help > /dev/null
 
-export MESON_VER="0.58.1"
+export MESON_VER="0.60.3"
 
 echo "==== Installing Meson ===="
 if ! sudo ${APT_GET} satisfy "meson (>= ${MESON_VER})" ; then


### PR DESCRIPTION
Minimum meson version in upstream freeciv is likely to get bumped to 0.60 soon ( https://github.com/freeciv/freeciv/pull/48 )