### PR TITLE
Bug fix: deleting/loading saved files fails.

### DIFF
--- a/freeciv-web/src/main/java/org/freeciv/servlet/ListSaveGames.java
+++ b/freeciv-web/src/main/java/org/freeciv/servlet/ListSaveGames.java
@@ -79,7 +79,13 @@ public class ListSaveGames extends HttpServlet {
 
 					for (File file : files) {
 						if (file.isFile()) {
-							buffer.append(file.getName().replaceAll(".sav.xz", ""));
+							String name = file.getName();
+							if (name.endsWith(".sav.xz")) {
+								name = name.replaceAll(".sav.xz", "");
+							}else if (name.endsWith(".sav.zst")) {
+								name = name.replaceAll(".sav.zst", "");
+							}
+							buffer.append(name);
 							buffer.append(';');
 						}
 					}


### PR DESCRIPTION
Changes:
- Server saves the file in different possible formats, including '.xz' and '.zst'. Currently some logic hardcodes the filename to use the '.xz' extension, which causes failures when the file is saved as '.zst'. This happends when a game is loaded and saved again. See https://gist.github.com/SiyuanQi/f5890efc30c661b5212adc0fb233e8c1 for a screenshot.
- Keep the login logic consistent with LoginUser.java: https://github.com/freeciv/freeciv-web/blob/4752797b8ee7b3abef8e1a4dc431bde34b99e221/freeciv-web/src/main/java/org/freeciv/servlet/LoginUser.java#L83-L84