### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ under the GNU Affero General Public License. See [License](LICENSE.txt) for the 
 Live servers
 ------------
 Currently known servers based on Freeciv-web, which are open source in compliance with [the AGPL license](https://github.com/freeciv/freeciv-web/blob/develop/LICENSE.txt):
-- [FCIV.NET](https://www.fciv.net) [https://github.com/fciv-net/fciv-net]
-- [freecivweb.org](https://www.freecivweb.org) [https://github.com/Lexxie9952/fcw.org-server]
+- [freecivweb.org](https://www.freecivweb.com) [https://github.com/Lexxie9952/fcw.org-server] Main FCW community. Single player, Multiplayer, Longuturn, Play-by-Email, Hotseat.
+- [FCIV.NET](https://www.fciv.net) [https://github.com/fciv-net/fciv-net] (Developing FCW for 3D using WebGL). Single player, Multiplayer.
 - [moving borders](https://fcw.movingborders.es)  [https://github.com/lonemadmax/freeciv-web] (Everything except longturn and real-Earth)
-- [Freeciv Tactics & Triumph](https://www.tacticsandtriumph.com)  [https://github.com/Canik05/freeciv-tnt] Freeciv Games & Mods (No PBEM)
 
 Freeciv-web screenshots:
 ------------------------


### PR DESCRIPTION
update on migration of freecivweb.org to freecivweb.com
better notes on game types for each site and 2D / 3D format
remove the now extinct-for-two-years site, tactics and triumph