### PR TITLE
WASM Server Build Support

### DIFF
--- a/freeciv/apply_wasm_server_patches.sh
+++ b/freeciv/apply_wasm_server_patches.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+
+declare -a PATCHLIST=(
+  "create_virtual_sockets_interface"
+  "disable_curl"
+  "switch_netintf_to_virtual"
+  "switch_sernet_to_virtual"
+  "fix_missing_type_declaration"
+  "add_breaks_into_loops_for_js"
+  "update-cross-file"
+  "make_emsbuild_for_server"
+  "update-meson-build"
+)
+
+apply_patch() {
+  echo "*** Applying $1.patch ***"
+  if ! patch -u -p1 -d freeciv < patches-wasm-server/$1.patch ; then
+    echo "APPLYING PATCH $1.patch FAILED!"
+    return 1
+  fi
+  echo "=== $1.patch applied ==="
+}
+
+for patch in "${PATCHLIST[@]}"
+do
+  if test "${patch}.patch" = "$APPLY_UNTIL" ; then
+    echo "$patch not applied as requested to stop"
+    break
+  fi
+  if ! apply_patch $patch ; then
+    echo "Patching failed ($patch.patch)" >&2
+    exit 1
+  fi
+done

--- a/freeciv/build_jansson_lib.sh
+++ b/freeciv/build_jansson_lib.sh
@@ -1,0 +1,14 @@
+# Build Jansson library for emscripten
+if ! test -f "freeciv/jansson/jansson_private_config.h.in" ; then
+  echo "Jansson source not found in \"${JANSSON_ROOT}\"" >&2
+  exit 1
+fi
+cd freeciv/jansson || exit 1
+export CFLAGS="-pthread"
+export CXXFLAGS="-pthread"
+export LDFLAGS="-pthread"
+emconfigure ./configure
+emmake make
+
+cd ../.. || exit 1
+

--- a/freeciv/dl_jansson_lib.sh
+++ b/freeciv/dl_jansson_lib.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S bash -e
+# Downloads and places the Jansson library source code in jansson/
+# Remove old version
+rm -Rf jansson
+# Download Jansson source code
+wget https://github.com/akheron/jansson/releases/download/v2.15.0/jansson-2.15.0.tar.gz
+tar -xzf jansson-2.15.0.tar.gz
+mv jansson-2.15.0 freeciv/jansson
+rm jansson-2.15.0.tar.gz

--- a/freeciv/patches-wasm-server/add_breaks_into_loops_for_js.patch
+++ b/freeciv/patches-wasm-server/add_breaks_into_loops_for_js.patch
@@ -1,0 +1,74 @@
+diff -ruN freeciv-base/server/srv_main.c freeciv/server/srv_main.c
+--- freeciv-base/server/srv_main.c	2026-02-03 10:52:54.223187745 +1000
++++ freeciv/server/srv_main.c	2026-02-04 16:02:16.111647221 +1000
+@@ -41,6 +41,9 @@
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#ifdef __EMSCRIPTEN__
++#include <emscripten.h>
++#endif
+ 
+ /* dependencies/lua */
+ #include "lua.h" /* lua_Integer */
+@@ -2064,6 +2067,9 @@
+   int retries = 0;
+ 
+   while (identity_number_is_used(increment_identity_number())) {
++    #ifdef __EMSCRIPTEN__
++    emscripten_sleep(0);
++    #endif
+     /* Try again */
+     if (++retries >= IDENTITY_NUMBER_SIZE) {
+       /* Always fails. */
+@@ -2925,6 +2931,9 @@
+ 
+   fc_assert(S_S_RUNNING == server_state());
+   while (S_S_RUNNING == server_state()) {
++    #ifdef __EMSCRIPTEN__
++    emscripten_sleep(0);
++    #endif
+     /* The beginning of a turn.
+      *
+      * We have to initialize data as well as do some actions.  However when
+@@ -2998,6 +3007,9 @@
+       }
+ 
+       while (server_sniff_all_input() == S_E_OTHERWISE) {
++        #ifdef __EMSCRIPTEN__
++        emscripten_sleep(0);
++        #endif
+         /* Nothing */
+       }
+ 
+@@ -3583,6 +3595,9 @@
+ 
+   /* Run server loop */
+   do {
++    #ifdef __EMSCRIPTEN__
++    emscripten_sleep(0);
++    #endif
+     set_server_state(S_S_INITIAL);
+ 
+     /* Load a script file. */
+@@ -3600,6 +3615,9 @@
+                srvarg.port);
+     /* Remain in S_S_INITIAL until all players are ready. */
+     while (S_E_FORCE_END_OF_SNIFF != server_sniff_all_input()) {
++      #ifdef __EMSCRIPTEN__
++      emscripten_sleep(0);
++      #endif
+       /* When force_end_of_sniff is used in pregame, it means that the server
+        * is ready to start (usually set within start_game()). */
+     }
+@@ -3614,6 +3632,9 @@
+ 
+     /* Remain in S_S_OVER until players log out */
+     while (conn_list_size(game.est_connections) > 0) {
++      #ifdef __EMSCRIPTEN__
++      emscripten_sleep(0);
++      #endif
+       server_sniff_all_input();
+     }
+ 
+

--- a/freeciv/patches-wasm-server/create_virtual_sockets_interface.patch
+++ b/freeciv/patches-wasm-server/create_virtual_sockets_interface.patch
@@ -1,0 +1,633 @@
+diff -ruN freeciv-base/utility/netintf_virtual.c freeciv/utility/netintf_virtual.c
+--- freeciv-base/utility/netintf_virtual.c	1970-01-01 10:00:00.000000000 +1000
++++ freeciv/utility/netintf_virtual.c	2026-02-04 15:11:09.982875378 +1000
+@@ -0,0 +1,545 @@
++/***********************************************************************
++ Freeciv - Copyright (C) 1996 - A Kjeldberg, L Gregersen, P Unold
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 2, or (at your option)
++   any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++***********************************************************************/
++
++/***********************************************************************
++  Virtual socket implementation for Emscripten/WebAssembly builds.
++  Replaces native sockets with in-memory buffers accessible from JS.
++***********************************************************************/
++
++#ifdef __EMSCRIPTEN__
++
++#include <emscripten.h>
++#include <errno.h>
++#include <string.h>
++#include <stdlib.h>
++
++#include "fc_prehdrs.h"
++#include "log.h"
++#include "mem.h"
++#include "support.h"
++#include "netintf.h"
++#include "netintf_virtual.h"
++
++/*--- Static data ---*/
++static struct virtual_socket vsock_table[VSOCK_MAX_SOCKETS];
++static int vsock_listen_fd = -1;
++static int vsock_next_fd = VSOCK_BASE_FD;
++static bool vsock_initialized = false;
++
++/*=======================================================================
++  Buffer Operations
++=======================================================================*/
++
++void vsock_buffer_init(struct vsock_buffer *buf, size_t capacity)
++{
++  buf->data = fc_calloc(1, capacity);
++  buf->capacity = capacity;
++  buf->head = 0;
++  buf->tail = 0;
++  buf->size = 0;
++}
++
++void vsock_buffer_free(struct vsock_buffer *buf)
++{
++  if (buf->data) {
++    free(buf->data);
++    buf->data = NULL;
++  }
++  buf->capacity = 0;
++  buf->size = 0;
++}
++
++int vsock_buffer_write(struct vsock_buffer *buf, const void *data, size_t len)
++{
++  if (!buf->data || len == 0) return 0;
++
++  size_t available = buf->capacity - buf->size;
++  size_t to_write = (len < available) ? len : available;
++
++  const unsigned char *src = (const unsigned char *)data;
++
++  for (size_t i = 0; i < to_write; i++) {
++    buf->data[buf->tail] = src[i];
++    buf->tail = (buf->tail + 1) % buf->capacity;
++  }
++  buf->size += to_write;
++
++  return (int)to_write;
++}
++
++int vsock_buffer_read(struct vsock_buffer *buf, void *data, size_t max_len)
++{
++  if (!buf->data || buf->size == 0) {
++    errno = EWOULDBLOCK;
++    return -1;
++  }
++
++  size_t to_read = (max_len < buf->size) ? max_len : buf->size;
++  unsigned char *dst = (unsigned char *)data;
++
++  for (size_t i = 0; i < to_read; i++) {
++    dst[i] = buf->data[buf->head];
++    buf->head = (buf->head + 1) % buf->capacity;
++  }
++  buf->size -= to_read;
++
++  return (int)to_read;
++}
++
++/*=======================================================================
++  Virtual Socket Management
++=======================================================================*/
++
++static void vsock_init_table(void)
++{
++  if (!vsock_initialized) {
++    memset(vsock_table, 0, sizeof(vsock_table));
++    vsock_initialized = true;
++  }
++}
++
++int vsock_alloc(void)
++{
++  vsock_init_table();
++
++  for (int i = 0; i < VSOCK_MAX_SOCKETS; i++) {
++    if (vsock_table[i].state == VSOCK_CLOSED) {
++      vsock_table[i].fd = vsock_next_fd++;
++      vsock_table[i].state = VSOCK_CONNECTING; /* mark as in-use */
++      vsock_table[i].nonblocking = false;
++      vsock_table[i].client_id = -1;
++      return vsock_table[i].fd;
++    }
++  }
++
++  errno = EMFILE;
++  return -1;
++}
++
++void vsock_free(struct virtual_socket *vs)
++{
++  if (!vs) return;
++
++  vsock_buffer_free(&vs->recv_buf);
++  vsock_buffer_free(&vs->send_buf);
++
++  if (vs->pending_connections) {
++    free(vs->pending_connections);
++    vs->pending_connections = NULL;
++  }
++
++  memset(vs, 0, sizeof(*vs));
++}
++
++struct virtual_socket *vsock_get(int fd)
++{
++  if (fd < VSOCK_BASE_FD) return NULL;
++
++  for (int i = 0; i < VSOCK_MAX_SOCKETS; i++) {
++    if (vsock_table[i].fd == fd && vsock_table[i].state != VSOCK_CLOSED) {
++      return &vsock_table[i];
++    }
++  }
++  return NULL;
++}
++
++struct virtual_socket *vsock_find_by_client(int client_id)
++{
++  for (int i = 0; i < VSOCK_MAX_SOCKETS; i++) {
++    if (vsock_table[i].client_id == client_id
++        && vsock_table[i].state == VSOCK_CONNECTED) {
++      return &vsock_table[i];
++    }
++  }
++  return NULL;
++}
++
++/*=======================================================================
++  Socket API Replacements (for sernet.c)
++=======================================================================*/
++
++int vsock_socket(int domain, int type, int protocol)
++{
++  return vsock_alloc();
++}
++
++int vsock_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
++{
++  struct virtual_socket *vs = vsock_get(sockfd);
++  if (!vs) {
++    errno = EBADF;
++    return -1;
++  }
++  /* Virtual bind - just mark as ready */
++  return 0;
++}
++
++int vsock_listen(int sockfd, int backlog)
++{
++  struct virtual_socket *vs = vsock_get(sockfd);
++  if (!vs) {
++    errno = EBADF;
++    return -1;
++  }
++
++  vs->state = VSOCK_LISTENING;
++  vs->pending_capacity = (backlog > 0) ? backlog : 16;
++  vs->pending_connections = fc_calloc(vs->pending_capacity, sizeof(int));
++  vs->pending_count = 0;
++
++  vsock_listen_fd = sockfd;
++
++  log_verbose("Virtual socket %d listening (backlog=%d)", sockfd, backlog);
++  return 0;
++}
++
++int vsock_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
++{
++  struct virtual_socket *listen_vs = vsock_get(sockfd);
++  if (!listen_vs || listen_vs->state != VSOCK_LISTENING) {
++    errno = EINVAL;
++    return -1;
++  }
++
++  if (listen_vs->pending_count == 0) {
++    errno = EWOULDBLOCK;
++    return -1;
++  }
++
++  /* Pop first pending connection */
++  int client_fd = listen_vs->pending_connections[0];
++
++  /* Shift remaining */
++  for (int i = 1; i < listen_vs->pending_count; i++) {
++    listen_vs->pending_connections[i - 1] = listen_vs->pending_connections[i];
++  }
++  listen_vs->pending_count--;
++
++  /* Fill in dummy address if requested */
++  if (addr && addrlen) {
++    struct sockaddr_in *sin = (struct sockaddr_in *)addr;
++    memset(sin, 0, sizeof(*sin));
++    sin->sin_family = AF_INET;
++    sin->sin_addr.s_addr = htonl(0x7F000001); /* 127.0.0.1 */
++    *addrlen = sizeof(*sin);
++  }
++
++  log_verbose("Virtual accept: new connection fd=%d", client_fd);
++  return client_fd;
++}
++
++/*=======================================================================
++  fc_* Network Interface Replacements
++=======================================================================*/
++
++int fc_connect(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen)
++{
++  /* Server doesn't use connect - it accepts connections */
++  /* For future client support, this would queue a connection request */
++  errno = ENOSYS;
++  return -1;
++}
++
++int fc_select(int n, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
++              fc_timeval *timeout)
++{
++  int ready = 0;
++  fd_set new_readfds, new_writefds, new_exceptfds;
++
++  FC_FD_ZERO(&new_readfds);
++  FC_FD_ZERO(&new_writefds);
++  FC_FD_ZERO(&new_exceptfds);
++
++  /* Check each virtual socket */
++  for (int i = 0; i < VSOCK_MAX_SOCKETS; i++) {
++    struct virtual_socket *vs = &vsock_table[i];
++    if (vs->state == VSOCK_CLOSED) continue;
++
++    int fd = vs->fd;
++
++    /* Check read readiness */
++    if (readfds && FD_ISSET(fd, readfds)) {
++      bool readable = false;
++
++      if (vs->state == VSOCK_LISTENING && vs->pending_count > 0) {
++        readable = true;
++      } else if (vs->state == VSOCK_CONNECTED && vs->recv_buf.size > 0) {
++        readable = true;
++      }
++
++      if (readable) {
++        FD_SET(fd, &new_readfds);
++        ready++;
++      }
++    }
++
++    /* Check write readiness */
++    if (writefds && FD_ISSET(fd, writefds)) {
++      if (vs->state == VSOCK_CONNECTED) {
++        /* Always writable (we buffer internally) */
++        FD_SET(fd, &new_writefds);
++        ready++;
++      }
++    }
++
++    /* Exceptfds - not used for virtual sockets */
++  }
++
++  if (readfds) *readfds = new_readfds;
++  if (writefds) *writefds = new_writefds;
++  if (exceptfds) FC_FD_ZERO(exceptfds);
++
++  return ready;
++}
++
++int fc_readsocket(int sock, void *buf, size_t size)
++{
++  struct virtual_socket *vs = vsock_get(sock);
++  if (!vs) {
++    errno = EBADF;
++    return -1;
++  }
++
++  if (vs->state != VSOCK_CONNECTED) {
++    errno = ENOTCONN;
++    return -1;
++  }
++
++  if (vs->recv_buf.size == 0) {
++    if (vs->nonblocking) {
++      errno = EWOULDBLOCK;
++      return -1;
++    }
++    return 0; /* No data available */
++  }
++
++  return vsock_buffer_read(&vs->recv_buf, buf, size);
++}
++
++int fc_writesocket(int sock, const void *buf, size_t size)
++{
++  struct virtual_socket *vs = vsock_get(sock);
++  if (!vs) {
++    errno = EBADF;
++    return -1;
++  }
++
++  if (vs->state != VSOCK_CONNECTED) {
++    errno = ENOTCONN;
++    return -1;
++  }
++
++  int written = vsock_buffer_write(&vs->send_buf, buf, size);
++
++  /* Notify JS that data is available */
++  EM_ASM({
++    if (typeof Module !== 'undefined' && Module.onServerData) {
++      Module.onServerData($0);
++    }
++  }, vs->client_id);
++
++  emscripten_sleep(0);
++
++  return written;
++}
++
++void fc_closesocket(int sock)
++{
++  struct virtual_socket *vs = vsock_get(sock);
++  if (!vs) return;
++
++  int client_id = vs->client_id;
++
++  /* Notify JS of disconnection */
++  if (client_id >= 0) {
++    EM_ASM({
++      if (typeof Module !== 'undefined' && Module.onServerDisconnect) {
++        Module.onServerDisconnect($0);
++      }
++    }, client_id);
++  }
++
++  log_verbose("Virtual socket %d closed (client_id=%d)", sock, client_id);
++  vsock_free(vs);
++}
++
++void fc_init_network(void)
++{
++  vsock_init_table();
++  log_verbose("Virtual network initialized for Emscripten");
++}
++
++void fc_shutdown_network(void)
++{
++  /* Clean up all sockets */
++  for (int i = 0; i < VSOCK_MAX_SOCKETS; i++) {
++    if (vsock_table[i].state != VSOCK_CLOSED) {
++      vsock_free(&vsock_table[i]);
++    }
++  }
++  vsock_initialized = false;
++  log_verbose("Virtual network shutdown");
++}
++
++void fc_nonblock(int sockfd)
++{
++  struct virtual_socket *vs = vsock_get(sockfd);
++  if (vs) {
++    vs->nonblocking = true;
++  }
++}
++
++/*=======================================================================
++  JavaScript Interface (Exported via EMSCRIPTEN_KEEPALIVE)
++=======================================================================*/
++
++EMSCRIPTEN_KEEPALIVE
++int vsock_js_connect(int client_id)
++{
++  struct virtual_socket *listen_vs = vsock_get(vsock_listen_fd);
++  if (!listen_vs || listen_vs->state != VSOCK_LISTENING) {
++    log_error("vsock_js_connect: no listening socket");
++    return -1;
++  }
++
++  /* Create new socket for this connection */
++  int new_fd = vsock_alloc();
++  if (new_fd < 0) {
++    log_error("vsock_js_connect: failed to allocate socket");
++    return -1;
++  }
++
++  struct virtual_socket *vs = vsock_get(new_fd);
++  vs->state = VSOCK_CONNECTED;
++  vs->client_id = client_id;
++  vs->nonblocking = true;
++  vsock_buffer_init(&vs->recv_buf, 65536);
++  vsock_buffer_init(&vs->send_buf, 65536);
++
++  /* Queue in listen socket's pending list */
++  if (listen_vs->pending_count < listen_vs->pending_capacity) {
++    listen_vs->pending_connections[listen_vs->pending_count++] = new_fd;
++    log_verbose("vsock_js_connect: client %d queued as fd %d", client_id, new_fd);
++    return new_fd;
++  }
++
++  /* Queue full - reject */
++  vsock_free(vs);
++  log_error("vsock_js_connect: connection queue full");
++  return -1;
++}
++
++EMSCRIPTEN_KEEPALIVE
++int vsock_js_send(int client_id, const void *data, size_t len)
++{
++  struct virtual_socket *vs = vsock_find_by_client(client_id);
++  if (!vs) {
++    log_error("vsock_js_send: unknown client %d", client_id);
++    return -1;
++  }
++
++  /* Write to recv_buf - this is data FROM client TO server */
++  return vsock_buffer_write(&vs->recv_buf, data, len);
++}
++
++EMSCRIPTEN_KEEPALIVE
++int vsock_js_recv(int client_id, void *buf, size_t max_len)
++{
++  struct virtual_socket *vs = vsock_find_by_client(client_id);
++  if (!vs) {
++    return -1;
++  }
++
++  if (vs->send_buf.size == 0) {
++    return 0; /* No data */
++  }
++
++  /* Read from send_buf - this is data FROM server TO client */
++  return vsock_buffer_read(&vs->send_buf, buf, max_len);
++}
++
++EMSCRIPTEN_KEEPALIVE
++int vsock_js_disconnect(int client_id)
++{
++  struct virtual_socket *vs = vsock_find_by_client(client_id);
++  if (vs) {
++    log_verbose("vsock_js_disconnect: client %d", client_id);
++    /* Mark as closed - server will detect on next operation */
++    vs->recv_buf.size = 0; /* Signal EOF */
++    vs->state = VSOCK_CLOSED;
++  }
++  return 0;
++}
++
++EMSCRIPTEN_KEEPALIVE
++int vsock_js_poll(void)
++{
++  /* Return count of sockets with pending data */
++  int count = 0;
++  for (int i = 0; i < VSOCK_MAX_SOCKETS; i++) {
++    if (vsock_table[i].state == VSOCK_CONNECTED
++        && vsock_table[i].send_buf.size > 0) {
++      count++;
++    }
++  }
++  return count;
++}
++
++EMSCRIPTEN_KEEPALIVE
++int vsock_js_has_data(int client_id)
++{
++  struct virtual_socket *vs = vsock_find_by_client(client_id);
++  if (!vs) return 0;
++  return (vs->send_buf.size > 0) ? 1 : 0;
++}
++
++struct fc_sockaddr_list *net_lookup_service(const char *name, int port, enum fc_addr_family family)          {
++  /* Virtual sockets don't need real address lookup - return empty list or
++     single dummy entry for binding purposes */
++  struct fc_sockaddr_list *addrs = fc_sockaddr_list_new();
++  union fc_sockaddr *result = fc_malloc(sizeof(*result));
++
++  memset(result, 0, sizeof(*result));
++  result->saddr.sa_family = AF_INET;
++  result->saddr_in4.sin_port = htons(port);
++  result->saddr_in4.sin_addr.s_addr = htonl(INADDR_ANY);
++
++  fc_sockaddr_list_append(addrs, result);
++  return addrs;
++}
++
++void sockaddr_debug(union fc_sockaddr *addr, enum log_level lvl)      
++{                                 
++  /* Just log that it's a virtual address */                          
++  log_base(lvl, "Virtual socket address (port: %d)", ntohs(addr->saddr_in4.sin_port));
++}                                 
++
++int sockaddr_size(union fc_sockaddr *addr)                            
++{                                 
++  return sizeof(struct sockaddr_in);  /* Always IPv4 for virtual */   
++}                                 
++
++bool fc_inet_aton(const char *cp, struct in_addr *inp, bool addr_none_ok)
++{                                 
++  /* Not used meaningfully for virtual sockets, but provide basic impl */                                                                      
++  inp->s_addr = INADDR_ANY;
++  return TRUE;                    
++}                                 
++
++int addr_family_for_announce_type(enum announce_type announce)        
++{                                 
++  /* LAN announcements not supported in virtual socket mode */        
++  return AF_UNSPEC;               
++}
++
++#endif /* __EMSCRIPTEN__ */
+diff -ruN freeciv-base/utility/netintf_virtual.h freeciv/utility/netintf_virtual.h
+--- freeciv-base/utility/netintf_virtual.h	1970-01-01 10:00:00.000000000 +1000
++++ freeciv/utility/netintf_virtual.h	2026-02-04 15:11:09.983875386 +1000
+@@ -0,0 +1,79 @@
++#ifndef FC__NETINTF_VIRTUAL_H
++#define FC__NETINTF_VIRTUAL_H
++
++#ifdef __EMSCRIPTEN__
++
++#include <emscripten.h>
++#include <stddef.h>
++#include <stdbool.h>
++
++/* Virtual socket descriptor range (avoid conflicts with real fds) */
++#define VSOCK_BASE_FD      1000
++#define VSOCK_MAX_SOCKETS  256
++
++/* Virtual socket states */
++enum vsock_state {
++  VSOCK_CLOSED = 0,
++  VSOCK_LISTENING,
++  VSOCK_CONNECTED,
++  VSOCK_CONNECTING
++};
++
++/* Ring buffer for socket data */
++struct vsock_buffer {
++  unsigned char *data;
++  size_t capacity;
++  size_t head;      /* read position */
++  size_t tail;      /* write position */
++  size_t size;      /* current data size */
++};
++
++/* Virtual socket structure */
++struct virtual_socket {
++  int fd;                       /* virtual file descriptor */
++  enum vsock_state state;
++  bool nonblocking;
++
++  struct vsock_buffer recv_buf; /* incoming data from JS */
++  struct vsock_buffer send_buf; /* outgoing data to JS */
++
++  /* For listening sockets: pending connections queue */
++  int *pending_connections;
++  int pending_count;
++  int pending_capacity;
++
++  /* For connected sockets: peer reference */
++  int peer_fd;                  /* connected peer's fd */
++  int client_id;                /* JS client identifier */
++};
++
++/*--- Internal API ---*/
++int vsock_alloc(void);
++void vsock_free(struct virtual_socket *vs);
++struct virtual_socket *vsock_get(int fd);
++struct virtual_socket *vsock_find_by_client(int client_id);
++
++/*--- Buffer operations ---*/
++void vsock_buffer_init(struct vsock_buffer *buf, size_t capacity);
++void vsock_buffer_free(struct vsock_buffer *buf);
++int vsock_buffer_write(struct vsock_buffer *buf, const void *data, size_t len);
++int vsock_buffer_read(struct vsock_buffer *buf, void *data, size_t max_len);
++
++/*--- Socket replacements for sernet.c ---*/
++int vsock_socket(int domain, int type, int protocol);
++int vsock_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
++int vsock_listen(int sockfd, int backlog);
++int vsock_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
++
++/*--- Exported to JS via Emscripten ---*/
++EMSCRIPTEN_KEEPALIVE int vsock_js_connect(int client_id);
++EMSCRIPTEN_KEEPALIVE int vsock_js_send(int client_id, const void *data, size_t len);
++EMSCRIPTEN_KEEPALIVE int vsock_js_recv(int client_id, void *buf, size_t max_len);
++EMSCRIPTEN_KEEPALIVE int vsock_js_disconnect(int client_id);
++EMSCRIPTEN_KEEPALIVE int vsock_js_poll(void);
++EMSCRIPTEN_KEEPALIVE int vsock_js_has_data(int client_id);
++
++#endif /* __EMSCRIPTEN__ */
++
++#endif /* FC__NETINTF_VIRTUAL_H */
++
+

--- a/freeciv/patches-wasm-server/disable_curl.patch
+++ b/freeciv/patches-wasm-server/disable_curl.patch
@@ -1,0 +1,74 @@
+diff -ruN freeciv-base/common/networking/dataio_json.c freeciv/common/networking/dataio_json.c
+--- freeciv-base/common/networking/dataio_json.c	2026-02-03 10:52:53.542182720 +1000
++++ freeciv/common/networking/dataio_json.c	2026-02-04 15:54:46.283998157 +1000
+@@ -19,7 +19,9 @@
+ 
+ #include "fc_prehdrs.h"
+ 
++#ifndef __EMSCRIPTEN__
+ #include <curl/curl.h>
++#endif
+ 
+ #include <limits.h>
+ #include <math.h>
+@@ -64,6 +66,7 @@
+                                         const struct plocation *location,
+                                         bool *dest);
+ 
++#ifndef __EMSCRIPTEN__
+ /**********************************************************************//**
+   Returns a CURL easy handle for name encoding and decoding
+ **************************************************************************/
+@@ -80,6 +83,7 @@
+ 
+   return curl_easy_handle;
+ }
++#endif /* __EMSCRIPTEN__ */
+ 
+ static int plocation_write_data(json_t *item,
+                                 const struct plocation *location,
+@@ -1147,6 +1151,11 @@
+                          const struct plocation *location,
+                          const char *value)
+ {
++  #ifdef __EMSCRIPTEN__
++  /* Emscripten have no libcurl. */
++  return dio_put_string_json(dout, location, value);
++
++  #else
+   int e;
+ 
+   if (dout->json) {
+@@ -1165,6 +1174,7 @@
+   }
+ 
+   return e;
++  #endif
+ }
+ 
+ /**********************************************************************//**
+@@ -1453,6 +1463,15 @@
+                           const struct plocation *location,
+                           char *dest, size_t max_dest_size)
+ {
++  #ifdef __EMSCRIPTEN__
++  /* Emscripten have no libcurl. */
++  if (pc->json_mode) {
++    return dio_get_string_json_internal(pc->json_packet, location,
++                                        dest, max_dest_size);
++  } else {
++    return dio_get_estring_raw(din, dest, max_dest_size);
++  }
++  #else
+   if (pc->json_mode) {
+     char *escaped_value;
+     char *unescaped_value;
+@@ -1487,6 +1506,7 @@
+   }
+ 
+   return TRUE;
++  #endif /* __EMSCRIPTEN__ */
+ }
+ 
+ #endif /* FREECIV_JSON_CONNECTION */
+

--- a/freeciv/patches-wasm-server/fix_missing_type_declaration.patch
+++ b/freeciv/patches-wasm-server/fix_missing_type_declaration.patch
@@ -1,0 +1,12 @@
+diff -ruN freeciv-base/server/stdinhand.c freeciv/server/stdinhand.c
+--- freeciv-base/server/stdinhand.c	2026-02-03 10:52:54.234187826 +1000
++++ freeciv/server/stdinhand.c	2026-02-04 15:56:39.853934853 +1000
+@@ -22,6 +22,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <time.h>
++#include <ctype.h>
+ 
+ #ifdef FREECIV_HAVE_LIBREADLINE
+ #include <readline/readline.h>
+

--- a/freeciv/patches-wasm-server/make_emsbuild_for_server.patch
+++ b/freeciv/patches-wasm-server/make_emsbuild_for_server.patch
@@ -1,0 +1,46 @@
+diff -ruN freeciv-base/platforms/emscripten/emsbuild.sh freeciv/platforms/emscripten/emsbuild.sh
+--- freeciv-base/platforms/emscripten/emsbuild.sh	2026-02-03 10:52:54.209187642 +1000
++++ freeciv/platforms/emscripten/emsbuild.sh	2026-02-05 12:05:40.729979741 +1000
+@@ -15,6 +15,7 @@
+ EMSDK_ROOT="$1"
+ BUILD_ROOT="$(pwd)"
+ PLATFORM_ROOT="$(cd $(dirname "$0") && pwd)"
++INSTALL_DIR="${HOME}/freeciv"
+ 
+ if test "${PLATFORM_ROOT}" = "${BUILD_ROOT}" ; then
+   echo "Run $0 from a separate build directory." >&2
+@@ -36,23 +37,23 @@
+ cd "${BUILD_ROOT}" || exit 1
+ 
+ sed -e "s,<EMSDK_ROOT>,${EMSDK_ROOT}," \
++    -e "s,<BUILD_ROOT>,${BUILD_ROOT}," \
++    -e "s,<PLATFORM_ROOT>,${PLATFORM_ROOT}," \
+     "${PLATFORM_ROOT}/setups/cross-ems.tmpl" > cross.txt
+ 
+-# Build SDL2 separately first, without USE_PTHREADS that
+-# the main build uses.
+-if ! embuilder build sdl2 sdl2_image sdl2_ttf sdl2_gfx sdl2_mixer ; then
+-  echo "SDL2 build failed!" >&2
+-  exit 1
+-fi
+-
+ if ! CC=emcc CXX=em++ AR=emar meson setup \
+      --cross-file=cross.txt \
++     -Dserver=freeciv-web \
++     -Dclients=[] \
++     -Dfcmp=cli \
++     -Djson-protocol=true \
++     -Dnls=false \
++     -Dprefix="${INSTALL_DIR}" \
++     -Doptimization=3 \
++     -Db_lto=true \
+      -Ddefault_library=static \
+-     -Ddebug=true \
+      -Daudio=none \
+-     -Dmwand=false \
+      -Dtools=[] \
+-     -Dclients=stub,sdl2 \
+      -Dfcmp=[] \
+      "${PLATFORM_ROOT}/../../"
+ then
+

--- a/freeciv/patches-wasm-server/switch_netintf_to_virtual.patch
+++ b/freeciv/patches-wasm-server/switch_netintf_to_virtual.patch
@@ -1,0 +1,20 @@
+diff -ruN freeciv-base/utility/netintf.c freeciv/utility/netintf.c
+--- freeciv-base/utility/netintf.c	2026-02-03 10:52:54.352188697 +1000
++++ freeciv/utility/netintf.c	2026-02-04 15:45:41.965238170 +1000
+@@ -14,6 +14,10 @@
+ /***********************************************************************
+   Common network interface.
+ ***********************************************************************/
++#ifdef __EMSCRIPTEN__
++/* For Emscripten builds, use virtual socket implementation */
++#include "netintf_virtual.c"
++#else
+ 
+ #ifdef HAVE_CONFIG_H
+ #include <fc_config.h>
+@@ -697,3 +701,4 @@
+ 
+   return AF_UNSPEC;
+ }
++#endif /* __EMSCRIPTEN__ */
+

--- a/freeciv/patches-wasm-server/switch_sernet_to_virtual.patch
+++ b/freeciv/patches-wasm-server/switch_sernet_to_virtual.patch
@@ -1,0 +1,29 @@
+diff -ruN freeciv-base/server/sernet.c freeciv/server/sernet.c
+--- freeciv-base/server/sernet.c	2026-02-03 10:52:54.231187804 +1000
++++ freeciv/server/sernet.c	2026-02-04 15:59:21.278246396 +1000
+@@ -91,6 +91,15 @@
+ 
+ #include "sernet.h"
+ 
++#ifdef __EMSCRIPTEN__
++#include <emscripten.h>
++#include "utility/netintf_virtual.h"
++#define socket(d,t,p)     vsock_socket(d,t,p)
++#define bind(s,a,l)       vsock_bind(s,a,l)
++#define listen(s,b)       vsock_listen(s,b)
++#define accept(s,a,l)     vsock_accept(s,a,l)
++#endif
++
+ static struct connection connections[MAX_NUM_CONNECTIONS];
+ 
+ static int *listen_socks;
+@@ -572,6 +581,9 @@
+ #endif /* FREECIV_HAVE_LIBREADLINE */
+ 
+   while (TRUE) {
++    #ifdef __EMSCRIPTEN__
++    emscripten_sleep(0);
++    #endif
+     int selret;
+ 
+     con_prompt_on();   /* accepting new input */

--- a/freeciv/patches-wasm-server/update-cross-file.patch
+++ b/freeciv/patches-wasm-server/update-cross-file.patch
@@ -1,0 +1,22 @@
+diff -ruN freeciv-base/platforms/emscripten/setups/cross-ems.tmpl freeciv/platforms/emscripten/setups/cross-ems.tmpl
+--- freeciv-base/platforms/emscripten/setups/cross-ems.tmpl	2026-02-03 10:52:54.209187642 +1000
++++ freeciv/platforms/emscripten/setups/cross-ems.tmpl	2026-02-05 12:07:02.650621571 +1000
+@@ -4,6 +4,17 @@
+ ar = '<EMSDK_ROOT>/upstream/emscripten/emar'
+ strip = '<EMSDK_ROOT>/upstream/emscripten/emstrip'
+ 
++[host_machine]
++system = 'emscripten'
++cpu_family = 'wasm32'
++cpu = 'generic'
++endian = 'little'
++
+ [properties]
++cross_inc_path = '<EMSDK_ROOT>/upstream/emscripten/cache/sysroot/include'
+ cross_lib_path = '<EMSDK_ROOT>/upstream/emscripten/system/lib'
+ crosser = false
++
++[built-in options]
++c_args = ['-I<PLATFORM_ROOT>/../../jansson/src/']
++c_link_args = ['-L<PLATFORM_ROOT>/../../jansson/src/.libs', '-ljansson']
+

--- a/freeciv/patches-wasm-server/update-meson-build.patch
+++ b/freeciv/patches-wasm-server/update-meson-build.patch
@@ -1,0 +1,54 @@
+diff -ruN freeciv-base/meson.build freeciv/meson.build
+--- freeciv-base/meson.build	2026-02-03 10:52:54.181187435 +1000
++++ freeciv/meson.build	2026-02-05 12:17:03.135616229 +1000
+@@ -243,6 +243,42 @@
+ #endif''',
+   name: 'emscripten')
+     emscripten = true
++    message('Emscripten cross-build detected')
++
++    # enable debug
++    add_global_arguments('-g',
++                         language : [ 'c', 'cpp'])
++    # use ZLIB for emscripten builds
++    add_global_arguments('-s', 'USE_ZLIB=1',
++                         language : [ 'c', 'cpp'])
++    # use SQLITE3 for emscripten builds
++    add_global_arguments('-s', 'USE_SQLITE3=1',
++                         language : [ 'c', 'cpp'])
++    # use ALWAYS_ROOT for emscripten builds
++    add_global_arguments('-DALWAYS_ROOT',
++                         language : [ 'c', 'cpp'])
++    # add ALLOW_MEMORY_GROWTH for emscripten builds
++    add_global_link_arguments('-s', 'ALLOW_MEMORY_GROWTH=1',
++                              language : [ 'c', 'cpp'])
++    # set stack size to 30mb
++    add_global_link_arguments('-s', 'STACK_SIZE=31457280',
++                              language : [ 'c', 'cpp'])
++    add_global_link_arguments('-s', 'ASYNCIFY_STACK_SIZE=31457280',
++                              language : [ 'c', 'cpp'])
++    # use ASYNCIFY for emscripten builds
++    add_global_link_arguments('-s', 'ASYNCIFY',
++                              language : [ 'c', 'cpp'])
++    # export malloc/free functions
++    add_global_link_arguments('-s', 'EXPORTED_FUNCTIONS=["_malloc","_free", "_main"]',
++                              language : [ 'c', 'cpp'])
++    # add HEAPU8 export for emscripten builds
++    add_global_link_arguments('-s', 'EXPORTED_RUNTIME_METHODS=["HEAPU8"]',
++                              language : [ 'c', 'cpp'])
++    # include ruleset files
++    add_global_link_arguments('--preload-file', join_paths(meson.source_root(), 'data/classic@data/classic'), language : [ 'c', 'cpp'])
++    add_global_link_arguments('--preload-file', join_paths(meson.source_root(), 'data/default@data/default'), language : [ 'c', 'cpp'])
++    add_global_link_arguments('--preload-file', join_paths(meson.source_root(), 'data/nation@data/nation'), language : [ 'c', 'cpp'])
++    add_global_link_arguments('--preload-file', join_paths(meson.source_root(), 'data/override@data/override'), language : [ 'c', 'cpp'])
+   else
+     emscripten = false
+   endif
+@@ -1306,6 +1342,7 @@
+   'utility/mem.c',
+   'utility/netfile.c',
+   'utility/netintf.c',
++  'utility/netintf_virtual.c',
+   'utility/rand.c',
+   'utility/randseed.c',
+   'utility/registry.c',

--- a/freeciv/prepare_wasm_server.sh
+++ b/freeciv/prepare_wasm_server.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd "${DIR}"
+
+export GIT_PATCHING="no"
+
+. ./version.txt
+
+# Allow the user to override how Freeciv is downloaded.
+if test -f dl_freeciv.sh ; then
+  DL_FREECIV=dl_freeciv.sh
+else
+  DL_FREECIV=dl_freeciv_default.sh
+fi
+
+if ! "./${DL_FREECIV}" "$FCREV" "$GIT_PATCHING" ; then
+  echo "Git checkout failed" >&2
+  exit 1
+fi
+
+if ! ./apply_patches.sh ; then
+  echo "Patching failed" >&2
+  exit 1
+fi
+
+if ! ./apply_wasm_server_patches.sh ; then
+  echo "Patching WASM server failed" >&2
+  exit 1
+fi
+
+if ! ./dl_jansson_lib.sh ; then
+  echo "Can't download Jansson JSON library" >&2
+  exit 1
+fi
+
+if ! ./build_jansson_lib.sh ; then
+  echo "Can't compile Jansson JSON library for WASM" >&2
+  exit 1
+fi
+
+rm -rf build
+mkdir build
+cd build
+bash ../freeciv/platforms/emscripten/emsbuild.sh ~/github/emsdk/
+cd ..


### PR DESCRIPTION
Patches for C code, cross file, meson config and emsbuild.sh that allow build of WASM server for Freeciv. Running `prepare_wasm_server.sh` results in 3 files in build folder to be used with WASM capable Freeciv-Web client: freeciv-web.js, freeciv-web.wasm and freeciv-web.data.

This is initial clean(er) codebase, that only supports classic ruleset.


https://github.com/user-attachments/assets/e27d83d4-5d79-4c4f-b4a2-40d4f9665128

